### PR TITLE
[feat] 캘린더 홈 화면 조회 API 구현

### DIFF
--- a/src/main/java/dgu/umc_app/domain/ai_plan/repository/AiPlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/ai_plan/repository/AiPlanRepository.java
@@ -1,7 +1,0 @@
-package dgu.umc_app.domain.ai_plan.repository;
-
-import dgu.umc_app.domain.ai_plan.entity.AiPlan;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
-}

--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
@@ -1,17 +1,55 @@
 package dgu.umc_app.domain.plan.controller;
 
-import dgu.umc_app.domain.plan.dto.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.PlanCreateResponse;
+import dgu.umc_app.domain.plan.dto.*;
+import dgu.umc_app.domain.user.entity.User;
+import dgu.umc_app.global.authorize.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@Tag(name="plan, description = 일정 등록/쪼개기/조회/관리 API")
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name="plan", description = "일정 등록/쪼개기/조회/관리 API")
 public interface PlanApi {
     @Operation(
             summary = "일정 등록 API",
             description = "사용자가 새로운 일정을 등록합니다. 제목, 설명, 마감일 등을 포함합니다.")
-    PlanCreateResponse createPlan(@RequestBody @Valid PlanCreateRequest request);
+    PlanCreateResponse createPlan(
+            @RequestBody @Valid PlanCreateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "월 단위 일정 조회 API",
+            description = "사용자가 특정 연도와 월에 등록한 일반/AI 일정을 모두 조회합니다. 쿼리 파라미터 year, month 사용."
+    )
+    List<CalendarMonthResponse> getSchedulesByMonth(
+            @Parameter(description = "조회할 연도", example = "2025") @RequestParam int year,
+            @Parameter(description = "조회할 월", example = "7") @RequestParam int month,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "미룬 일정 조회", description = "수행날짜가 지났지만 완료되지 않은 일정을 조회합니다.")
+    @GetMapping("/delayed")
+    List<DelayedPlanResponse> getDelayedPlans(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "일자별 일정 조회",
+            description = "특정 날짜의 일반 일정 및 AI 쪼개기 일정을 함께 조회합니다."
+    )
+    CalendarDayWrapperResponse getSchedulesByDay(
+            @Parameter(description = "조회할 날짜", example = "2025-07-13") @RequestParam LocalDate day,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
 
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/CalendarDayResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/CalendarDayResponse.java
@@ -1,0 +1,57 @@
+package dgu.umc_app.domain.plan.dto;
+
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.Priority;
+import dgu.umc_app.domain.plan.entity.Plan;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalTime;
+
+public record CalendarDayResponse (
+
+        @Schema(description = "일정 ID")
+        Long id,
+
+        @Schema(description = "AI 쪼개기 일정일 경우 상위 일정 제목")
+        String parentTitle,
+
+        @Schema(description = "상위일정 제목")
+        String title,
+
+        @Schema(description = "일정 유형(기본 or AI 쪼개기)")
+        String type,        // NORMAL or AI_SPLIT
+
+        @Schema(description = "각 일정의 시작 시간")
+        LocalTime startTime,
+
+        @Schema(description = "각 일정의 종료 시간")
+        LocalTime endTime,
+
+        @Schema(description = "각 일정의 우선순위")
+        Priority priority
+){
+
+    public static CalendarDayResponse from(Plan plan) {
+        return new CalendarDayResponse(
+                plan.getId(),
+                null,
+                plan.getTitle(),
+                "NORMAL",
+                plan.getExecuteDate().toLocalTime(),
+                plan.getDeadline().toLocalTime(),
+                plan.getPriority()
+        );
+    }
+
+    public static CalendarDayResponse from(AiPlan aiPlan) {
+        return new CalendarDayResponse(
+                aiPlan.getId(),
+                aiPlan.getPlan().getTitle(),
+                aiPlan.getDescription(),
+                "AI_SPLIT",
+                aiPlan.getStartTime(),
+                aiPlan.getEndTime(),
+                aiPlan.getPriority()
+        );
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/CalendarDayWrapperResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/CalendarDayWrapperResponse.java
@@ -1,0 +1,13 @@
+package dgu.umc_app.domain.plan.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record CalendarDayWrapperResponse(
+        @Schema(description = "총 일정 개수")
+        int totalCount,
+
+        @Schema(description = "해당 날짜의 일정 리스트")
+        List<CalendarDayResponse> schedules
+) { }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/CalendarMonthResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/CalendarMonthResponse.java
@@ -1,0 +1,22 @@
+package dgu.umc_app.domain.plan.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+
+public record CalendarMonthResponse (
+
+        @Schema(description = "해당날짜")
+        LocalDate date,
+
+        @Schema(description = "총 일정 갯수")
+        int scheduleCount,
+
+        @Schema(description = "모두 완료되었는지에 대한 여부")
+        boolean isAllDone
+) {
+    public LocalDate getDate() {
+        return this.date;
+    }
+}
+

--- a/src/main/java/dgu/umc_app/domain/plan/dto/DelayedPlanResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/DelayedPlanResponse.java
@@ -1,0 +1,28 @@
+package dgu.umc_app.domain.plan.dto;
+
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.Plan;
+
+import java.time.LocalDateTime;
+
+public record DelayedPlanResponse (
+        Long id,
+        String title,
+        LocalDateTime executeDate
+){
+    public static DelayedPlanResponse from(Plan plan) {
+        return new DelayedPlanResponse(
+                plan.getId(),
+                plan.getTitle(),
+                plan.getExecuteDate()
+        );
+    }
+
+    public static DelayedPlanResponse from(AiPlan aiPlan) {
+        return new DelayedPlanResponse(
+                aiPlan.getId(),
+                aiPlan.getDescription(),
+                aiPlan.getScheduledDate().atStartOfDay()
+        );
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateRequest.java
@@ -1,11 +1,13 @@
 package dgu.umc_app.domain.plan.dto;
 
 import dgu.umc_app.domain.plan.entity.Plan;
+import dgu.umc_app.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record PlanCreateRequest(
@@ -15,22 +17,27 @@ public record PlanCreateRequest(
         @Schema(description = "일정 제목")
         String title,
 
-        @NotBlank(message = "일정 내용은 필수입니다.")
-        @Schema(description = "일정 설명")
-        String description,
-
         @NotNull(message = "마감 기한은 필수입니다.")
         @Schema(description = "마감 기한")
-        LocalDateTime deadline
+        LocalDateTime deadline,
+
+        @NotNull(message = "일정 수행 날짜는 필수입니다.")
+        @Schema(description = "일정 수행 날짜")
+        LocalDateTime executeDate,
+
+        @NotBlank(message = "일정 내용은 필수입니다.")
+        @Schema(description = "일정 간단설명")
+        String description
 
 ) {
-    // 사용 시점에 User는 별도로 설정
-    public Plan toEntity() {
+    public Plan toEntity(User user) {
         return Plan.builder()
                 .title(title)
                 .description(description)
                 .deadline(deadline)
+                .executeDate(executeDate)
                 .isDone(false)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateResponse.java
@@ -3,7 +3,6 @@ package dgu.umc_app.domain.plan.dto;
 import dgu.umc_app.domain.plan.entity.Plan;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record PlanCreateResponse(
@@ -15,7 +14,7 @@ public record PlanCreateResponse(
         String title,
 
         @Schema(description = "일정 마감 기한")
-        LocalDate deadline,
+        LocalDateTime deadline,
 
         @Schema(description = "일정 완료 여부")
         boolean isDone

--- a/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/PlanCreateResponse.java
@@ -3,6 +3,7 @@ package dgu.umc_app.domain.plan.dto;
 import dgu.umc_app.domain.plan.entity.Plan;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record PlanCreateResponse(
@@ -14,7 +15,7 @@ public record PlanCreateResponse(
         String title,
 
         @Schema(description = "일정 마감 기한")
-        LocalDateTime deadline,
+        LocalDate deadline,
 
         @Schema(description = "일정 완료 여부")
         boolean isDone

--- a/src/main/java/dgu/umc_app/domain/plan/entity/AiPlan.java
+++ b/src/main/java/dgu/umc_app/domain/plan/entity/AiPlan.java
@@ -1,18 +1,17 @@
-package dgu.umc_app.domain.ai_plan.entity;
+package dgu.umc_app.domain.plan.entity;
 
-import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class AiPlan extends BaseEntity {
 
     @Id
@@ -26,6 +25,10 @@ public class AiPlan extends BaseEntity {
     @Column(nullable = false)
     private Long stepOrder; // 실행 순서
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Priority priority;  // 우선순위
+
     @Column(nullable = false, length = 50)
     private String description; // 실행 내용
 
@@ -33,18 +36,18 @@ public class AiPlan extends BaseEntity {
     private Long expectedDuration; // 예상 실행 시간
 
     @Column(nullable = false)
-    private LocalDate scheduledDate; // 진행 날짜
+    private LocalDate scheduledDate; // 진행 날짜(ex:2025-05-01)
+
+    @Column(nullable = false)
+    private LocalTime startTime;    // 시작 시간(ex: 18:00)
+
+    @Column(nullable = false)
+    private LocalTime endTime;      // 종료 시간(ex: 19:00)
 
     @Column(nullable = false)
     private boolean isDone; // 완료 체크
 
-    @Builder
-    public AiPlan(Plan plan, Long stepOrder, String description, Long expectedDuration, LocalDate scheduledDate, boolean isDone) {
-        this.plan = plan;
-        this.stepOrder = stepOrder;
-        this.description = description;
-        this.expectedDuration = expectedDuration;
-        this.scheduledDate = scheduledDate;
-        this.isDone = isDone;
-    }
+    @Column(nullable = false)
+    private boolean isDelayed = false;  // 미루기 여부
+
 }

--- a/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
+++ b/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
@@ -1,18 +1,18 @@
 package dgu.umc_app.domain.plan.entity;
 
+import dgu.umc_app.domain.plan.entity.Priority;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Plan extends BaseEntity {
 
     @Id
@@ -33,15 +33,14 @@ public class Plan extends BaseEntity {
     private LocalDateTime deadline; // 마감 기한
 
     @Column(nullable = false)
+    private LocalDateTime executeDate; // 실제 수행 시작날짜
+
+    @Column(nullable = false)
     private boolean isDone; // 완료 체크
 
-    @Builder(toBuilder = true)
-    public Plan(User user, String title, String description, LocalDateTime deadline, boolean isDone) {
-        this.user = user;
-        this.title = title;
-        this.description = description;
-        this.deadline = deadline;
-        this.isDone = isDone;
-    }
+    @Column(nullable = false)
+    private boolean isDelayed = false;  // 미루기 여부
 
+    @Enumerated(EnumType.STRING)
+    private Priority priority;
 }

--- a/src/main/java/dgu/umc_app/domain/plan/entity/Priority.java
+++ b/src/main/java/dgu/umc_app/domain/plan/entity/Priority.java
@@ -1,0 +1,5 @@
+package dgu.umc_app.domain.plan.entity;
+
+public enum Priority {
+    HIGH, MEDIUM, LOW
+}

--- a/src/main/java/dgu/umc_app/domain/plan/exception/AiPlanErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/plan/exception/AiPlanErrorCode.java
@@ -1,4 +1,4 @@
-package dgu.umc_app.domain.ai_plan.exception;
+package dgu.umc_app.domain.plan.exception;
 
 import dgu.umc_app.global.exception.ErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/dgu/umc_app/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/AiPlanRepository.java
@@ -1,0 +1,14 @@
+package dgu.umc_app.domain.plan.repository;
+
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
+    List<AiPlan> findByPlan_UserIdAndScheduledDateBetween(Long userId, LocalDate start, LocalDate end); //월별 조회
+    List<AiPlan> findByPlan_UserIdAndScheduledDate(Long userId, LocalDate scheduledDate); //일자별 조회
+    List<AiPlan> findByPlan_UserIdAndIsDelayedTrue(Long userId);
+
+}

--- a/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
@@ -3,5 +3,12 @@ package dgu.umc_app.domain.plan.repository;
 import dgu.umc_app.domain.plan.entity.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+    List<Plan> findByUserIdAndExecuteDateBetween(Long userId, LocalDateTime start, LocalDateTime end); //월별 조회
+    List<Plan> findByUserIdAndExecuteDate(Long userId, LocalDateTime executeDate); //일자별 조회
+    List<Plan> findByUserIdAndIsDelayedTrue(Long userId);   //미룬 일정 조회
 }

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
@@ -6,34 +6,31 @@ import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.domain.plan.exception.PlanErrorCode;
 import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.user.entity.User;
-import dgu.umc_app.domain.user.exception.UserErrorCode;
-import dgu.umc_app.domain.user.repository.UserRepository;
 import dgu.umc_app.global.exception.BaseException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PlanCommandService {
 
     private final PlanRepository planRepository;
-    private final UserRepository userRepository;
 
     @Transactional
-    public PlanCreateResponse createPlan(PlanCreateRequest request, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> BaseException.type(UserErrorCode.USER_NOT_FOUND));
+    public PlanCreateResponse createPlan(PlanCreateRequest request, User user) {
 
-        if (request.deadline().isBefore(java.time.LocalDateTime.now())){
+        LocalDateTime today = LocalDateTime.now();
+
+        if (request.deadline().isBefore(today)
+                || request.executeDate().isBefore(today)) {
             throw BaseException.type(PlanErrorCode.INVALID_DATE_RANGE);
         }
 
-        Plan plan = request.toEntity().toBuilder()
-                .user(user)
-                .build();
-
-        Plan savedPlan = planRepository.save(plan);
+        Plan savedPlan = planRepository.save(request.toEntity(user));
         return PlanCreateResponse.from(savedPlan);
     }
 }

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
@@ -1,0 +1,105 @@
+package dgu.umc_app.domain.plan.service;
+
+import dgu.umc_app.domain.plan.repository.AiPlanRepository;
+import dgu.umc_app.domain.plan.dto.CalendarDayResponse;
+import dgu.umc_app.domain.plan.dto.CalendarDayWrapperResponse;
+import dgu.umc_app.domain.plan.dto.CalendarMonthResponse;
+import dgu.umc_app.domain.plan.dto.DelayedPlanResponse;
+import dgu.umc_app.domain.plan.entity.Plan;
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.repository.PlanRepository;
+import dgu.umc_app.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlanQueryService{
+
+    private final PlanRepository planRepository;
+    private final AiPlanRepository aiPlanRepository;
+
+    public List<CalendarMonthResponse> getSchedulesByMonth(int year, int month, User user) {
+
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        LocalDateTime startDateTime = start.atStartOfDay();
+        LocalDateTime endDateTime = end.atTime(23, 59, 59);
+
+        Long userId = user.getId();
+        List<Plan> plans = planRepository.findByUserIdAndExecuteDateBetween(userId, startDateTime, endDateTime);
+        List<AiPlan> aiPlans = aiPlanRepository.findByPlan_UserIdAndScheduledDateBetween(userId, start, end);
+
+        Map<LocalDate, List<Boolean>> doneMap = new HashMap<>();
+
+        for (Plan plan : plans) {
+            LocalDateTime executeDate = plan.getExecuteDate();
+            doneMap.computeIfAbsent(executeDate.toLocalDate(), k -> new ArrayList<>())
+                    .add(plan.isDone());
+        }
+
+        for (AiPlan aiPlan : aiPlans) {
+            LocalDate scheduleDate = aiPlan.getScheduledDate();
+            doneMap.computeIfAbsent(scheduleDate, k -> new ArrayList<>())
+                    .add(aiPlan.isDone());
+        }
+
+        return doneMap.entrySet().stream()
+                .map(entry -> new CalendarMonthResponse(
+                        entry.getKey(),
+                        entry.getValue().size(),
+                        entry.getValue().stream().allMatch(Boolean::booleanValue)
+                ))
+                .sorted(Comparator.comparing(CalendarMonthResponse::getDate))
+                .collect(Collectors.toList());
+
+    }
+
+    public CalendarDayWrapperResponse getSchedulesByDate(LocalDate date, User user) {
+        Long userId = user.getId();
+
+        LocalDateTime dateTime = date.atStartOfDay();
+
+        List<Plan> plans = planRepository.findByUserIdAndExecuteDate(userId, dateTime);
+        List<AiPlan> aiPlans = aiPlanRepository.findByPlan_UserIdAndScheduledDate(userId, date);
+
+        List<CalendarDayResponse> result = new ArrayList<>();
+
+        for (Plan plan : plans) {
+            result.add(CalendarDayResponse.from(plan));
+        }
+
+        for (AiPlan aiPlan : aiPlans) {
+            result.add(CalendarDayResponse.from(aiPlan));
+        }
+
+        result.sort(Comparator.comparing(CalendarDayResponse::startTime, Comparator.nullsLast(Comparator.naturalOrder())));
+
+        int totalCount = plans.size() + aiPlans.size();
+
+        return new CalendarDayWrapperResponse(totalCount, result);
+    }
+
+    public List<DelayedPlanResponse> getDelayedPlans(User user) {
+        Long userId = user.getId();
+
+        List<Plan> delayedPlans = planRepository.findByUserIdAndIsDelayedTrue(userId);
+        List<AiPlan> delayedAiPlans = aiPlanRepository.findByPlan_UserIdAndIsDelayedTrue(userId);
+
+        List<DelayedPlanResponse> result = new ArrayList<>();
+        delayedPlans.forEach(plan -> result.add(DelayedPlanResponse.from(plan)));
+        delayedAiPlans.forEach(aiPlan -> result.add(DelayedPlanResponse.from(aiPlan)));
+
+        return result;
+    }
+
+}
+

--- a/src/main/java/dgu/umc_app/domain/review/entity/Review.java
+++ b/src/main/java/dgu/umc_app/domain/review/entity/Review.java
@@ -1,6 +1,6 @@
 package dgu.umc_app.domain.review.entity;
 
-import dgu.umc_app.domain.ai_plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.AiPlan;
 import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.global.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -1,8 +1,8 @@
 package dgu.umc_app.domain.review.service;
 
 
-import dgu.umc_app.domain.ai_plan.entity.AiPlan;
-import dgu.umc_app.domain.ai_plan.repository.AiPlanRepository;
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.repository.AiPlanRepository;
 import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
@@ -10,7 +10,7 @@ import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
 import dgu.umc_app.domain.review.entity.Review;
 import dgu.umc_app.domain.review.exception.ReviewErrorCode;
 import dgu.umc_app.domain.plan.exception.PlanErrorCode;
-import dgu.umc_app.domain.ai_plan.exception.AiPlanErrorCode;
+import dgu.umc_app.domain.plan.exception.AiPlanErrorCode;
 import dgu.umc_app.domain.review.repository.ReviewRepository;
 import dgu.umc_app.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
@@ -48,7 +48,6 @@ public class SecurityConfig {
                                 "/api/signup/duplicate",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/api/schedule",     // jwt 완료 후 지울 예정
                                 "/actuator/**"
                         ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #30 

<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 캘린더 홈 화면에서 보여지는 캘린더 월별 일정 조회기능 구현
- 하단부 미룬 일정을 보여주는 조회기능 구현

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
마감기한은 날짜만 다루는 것이 깔끔해보일 것 같아 plan 엔티티에서 LocalDate로 변경하였는데 와이어프레임을 보니 시간까지 작성되어있네요!
빠른 시일내로 deadline 타입 변경하도록 하겠습니다.
