### PR TITLE
[feat] 회고 날짜 검색, 회고 내용 수정 API 구현

### DIFF
--- a/src/main/java/dgu/umc_app/domain/ai_plan/repository/AiPlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/ai_plan/repository/AiPlanRepository.java
@@ -2,6 +2,15 @@ package dgu.umc_app.domain.ai_plan.repository;
 
 import dgu.umc_app.domain.ai_plan.entity.AiPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
+    @Query("""
+    SELECT ap FROM AiPlan ap
+    WHERE ap.id = :aiPlanId AND ap.plan.user.id = :userId
+""")
+    Optional<AiPlan> findByIdAndUserId(@Param("aiPlanId") Long aiPlanId, @Param("userId") Long userId);
 }

--- a/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
@@ -2,6 +2,15 @@ package dgu.umc_app.domain.plan.repository;
 
 import dgu.umc_app.domain.plan.entity.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+    @Query("""
+    SELECT p FROM Plan p
+    WHERE p.id = :planId AND p.user.id = :userId
+""")
+    Optional<Plan> findByIdAndUserId(@Param("planId") Long planId, @Param("userId") Long userId);
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -25,7 +25,8 @@ public interface ReviewApi {
 
     @Operation(summary = "회고 작성 후 저장 API",
             description = "특정 일정에 대한 회고(기분, 성취도, 만족도, 메모 등)를 작성하고 저장합니다.")
-    ReviewCreateResponse createReview(@RequestBody @Valid ReviewCreateRequest request);
+    ReviewCreateResponse createReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @RequestBody @Valid ReviewCreateRequest request);
 
     @Operation(summary = "날짜별 회고 목록 갯수 조회 API",
             description = "날짜에 작성된 회고의 갯수 목록을 날짜순으로 반환합니다.")

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -31,7 +31,7 @@ public interface ReviewApi {
     List<ReviewCountByDateResponse> getReviewCountByDate(@AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "단일 회고 상세 조회 API", description = "작성된 회고의 상세 정보를 조회합니다.")
-    ReviewDetailResponse getReview(@PathVariable Long reviewId);
+    ReviewDetailResponse getReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId);
 
     @Operation(summary = "특정 날짜의 회고 목록 조회 API", description = "현재 로그인한 사용자의 특정 날짜 회고 목록(날짜, 제목, 부제목)을 최신순으로 조회합니다.")
     List<ReviewListResponse> getReviewListByDate(
@@ -39,4 +39,9 @@ public interface ReviewApi {
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     );
 
+    @Operation(summary = "특정 회고 날짜 검색 API", description = "검색된 날짜에 작성된 회고의 갯수를 조회합니다.")
+    ReviewCountByDateResponse getReviewSearch(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.controller;
 
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
+import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewListResponse;
@@ -9,10 +10,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "review", description = "회고 작성/관리 API")
@@ -22,10 +26,17 @@ public interface ReviewApi {
             description = "특정 일정에 대한 회고(기분, 성취도, 만족도, 메모 등)를 작성하고 저장합니다.")
     ReviewCreateResponse createReview(@RequestBody @Valid ReviewCreateRequest request);
 
-    @Operation(summary = "회고 단일 상세 조회 API", description = "작성된 회고의 상세 정보를 조회합니다.")
+    @Operation(summary = "날짜별 회고 목록 갯수 조회 API",
+            description = "날짜에 작성된 회고의 갯수 목록을 날짜순으로 반환합니다.")
+    List<ReviewCountByDateResponse> getReviewCountByDate(@AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "단일 회고 상세 조회 API", description = "작성된 회고의 상세 정보를 조회합니다.")
     ReviewDetailResponse getReview(@PathVariable Long reviewId);
 
-    @Operation(summary = "회고 전체 목록 조회 API", description = "현재 로그인한 사용자의 회고 목록(날짜, 제목, 메모)을 최신순으로 조회합니다.")
-    List<ReviewListResponse> getReviewList(@Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+    @Operation(summary = "특정 날짜의 회고 목록 조회 API", description = "현재 로그인한 사용자의 특정 날짜 회고 목록(날짜, 제목, 부제목)을 최신순으로 조회합니다.")
+    List<ReviewListResponse> getReviewListByDate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.controller;
 
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
+import dgu.umc_app.domain.review.dto.request.ReviewUpdateRequest;
 import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
@@ -44,4 +45,9 @@ public interface ReviewApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     );
+
+    @Operation(summary = "회고 수정 API", description = "회고의 내용을 수정합니다.(기분, 성취도, 메모)")
+    public ReviewDetailResponse updateReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @PathVariable Long reviewId,
+                                             @RequestBody @Valid ReviewUpdateRequest request);
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.controller;
 
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
+import dgu.umc_app.domain.review.dto.request.ReviewUpdateRequest;
 import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
@@ -11,6 +12,7 @@ import dgu.umc_app.global.authorize.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -66,6 +68,15 @@ public class ReviewController implements ReviewApi{
     ) {
         return reviewQueryService.getReviewSearch(userDetails.getUser().getId(), date);
     }
+
+    //회고 수정
+    @PatchMapping("/update/{reviewId}")
+    public ReviewDetailResponse updateReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                             @PathVariable Long reviewId,
+                                             @RequestBody @Valid ReviewUpdateRequest request) {
+        return reviewCommandService.updateReview(userDetails.getId(), reviewId, request);
+    }
+
 
 
 

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -43,9 +43,11 @@ public class ReviewController implements ReviewApi{
 
     //개별 회고 상세 조회
     @GetMapping("/{reviewId}")
-    public ReviewDetailResponse getReview(@PathVariable Long reviewId) {
-        return reviewQueryService.getReview(reviewId);
+    public ReviewDetailResponse getReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                          @PathVariable Long reviewId) {
+        return reviewQueryService.getReview(userDetails.getId(), reviewId);
     }
+
 
     // 특정 날짜의 회고 목록 조회
     @GetMapping("/date")
@@ -55,6 +57,16 @@ public class ReviewController implements ReviewApi{
     ) {
         return reviewQueryService.getReviewListByUserIdAndDate(userDetails.getId(), date);
     }
+
+    //날짜 검색으로 인한 회고 블럭 조회
+    @GetMapping("/search")
+    public ReviewCountByDateResponse getReviewSearch(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return reviewQueryService.getReviewSearch(userDetails.getUser().getId(), date);
+    }
+
 
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.controller;
 
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
+import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewListResponse;
@@ -9,9 +10,11 @@ import dgu.umc_app.domain.review.service.ReviewQueryService;
 import dgu.umc_app.global.authorize.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -32,17 +35,26 @@ public class ReviewController implements ReviewApi{
         return reviewCommandService.saveReview(request);
     }
 
-    //개별 회고 상세조회
+    //회고록 날짜별 갯수 조회
+    @GetMapping("/countByDate")
+    public List<ReviewCountByDateResponse> getReviewCountByDate(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return reviewQueryService.getReviewCountByDate(userDetails.getUser().getId());
+    }
+
+    //개별 회고 상세 조회
     @GetMapping("/{reviewId}")
     public ReviewDetailResponse getReview(@PathVariable Long reviewId) {
         return reviewQueryService.getReview(reviewId);
     }
 
-    //회고 목록 조회
-    @GetMapping
-    public List<ReviewListResponse> getReviewList(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getId();
-        return reviewQueryService.getReviewListByUserId(userId);
+    // 특정 날짜의 회고 목록 조회
+    @GetMapping("/date")
+    public List<ReviewListResponse> getReviewListByDate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        return reviewQueryService.getReviewListByUserIdAndDate(userDetails.getId(), date);
     }
+
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -32,10 +32,12 @@ public class ReviewController implements ReviewApi{
 
 
      //회고 작성 후 저장
-    @PostMapping
-    public ReviewCreateResponse createReview(@RequestBody @Valid ReviewCreateRequest request) {
-        return reviewCommandService.saveReview(request);
-    }
+     @PostMapping
+     public ReviewCreateResponse createReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                              @RequestBody @Valid ReviewCreateRequest request) {
+         Long userId = userDetails.getId();
+         return reviewCommandService.saveReview(userId, request);
+     }
 
     //회고록 날짜별 갯수 조회
     @GetMapping("/countByDate")

--- a/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,9 +1,6 @@
 package dgu.umc_app.domain.review.dto.request;
 
-import dgu.umc_app.domain.ai_plan.entity.AiPlan;
-import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.domain.review.entity.Mood;
-import dgu.umc_app.domain.review.entity.Review;
 import jakarta.validation.constraints.*;
 
 public record ReviewCreateRequest(
@@ -17,31 +14,13 @@ public record ReviewCreateRequest(
         @NotNull(message = "기분은 필수입니다.")
         Mood mood,
 
-        @NotBlank @Size(max = 50 , message = "회고 제목은 50자 이내여야 합니다.")
-        String title,
-
         @Min(value = 0, message = "성취도는 0 이상이어야 합니다.")
         @Max(value = 100, message = "성취도는 100 이하여야 합니다.")
         int achievement,
-
-        @Min(value = 0, message = "만족도는 0 이상이어야 합니다.")
-        @Max(value = 100, message = "만족도는 100 이하여야 합니다.")
-        int satisfaction,
 
         @NotBlank(message = "회고 메모는 비워둘 수 없습니다.")
         @Size(max = 255, message = "회고 메모는 255자 이내여야 합니다.")
         String memo
 
 ) {
-        public Review toEntity(AiPlan aiPlan, Plan plan) {
-                return Review.builder()
-                        .aiPlan(aiPlan)
-                        .plan(plan)
-                        .mood(mood)
-                        .title(title)
-                        .achievement((byte) achievement)     // byte로 변환해서 저장
-                        .satisfaction((byte) satisfaction)   // byte로 변환해서 저장
-                        .memo(memo)
-                        .build();
-        }
 }

--- a/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewUpdateRequest.java
@@ -1,0 +1,19 @@
+package dgu.umc_app.domain.review.dto.request;
+
+import dgu.umc_app.domain.review.entity.Mood;
+import jakarta.validation.constraints.*;
+
+public record ReviewUpdateRequest(
+
+        @NotNull(message = "기분은 필수입니다.")
+        Mood mood,
+
+        @Min(value = 0, message = "성취도는 0 이상이어야 합니다.")
+        @Max(value = 100, message = "성취도는 100 이하여야 합니다.")
+        int achievement,
+
+        @NotBlank(message = "회고 메모는 비워둘 수 없습니다.")
+        @Size(max = 255, message = "회고 메모는 255자 이내여야 합니다.")
+        String memo
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCountByDateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCountByDateResponse.java
@@ -1,0 +1,9 @@
+package dgu.umc_app.domain.review.dto.response;
+
+import java.util.Date;
+
+public record ReviewCountByDateResponse(
+        Date date,
+        Long count
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCreateResponse.java
@@ -19,17 +19,17 @@ public record ReviewCreateResponse(
         @Schema(description = "일정 ID")
         Long planId,
 
-        @Schema(description = "기분")
-        Mood mood,
-
         @Schema(description = "회고 제목")
         String title,
 
+        @Schema(description = "회고 부제목")
+        String description,
+
+        @Schema(description = "기분")
+        Mood mood,
+
         @Schema(description = "성취도")
         byte achievement,
-
-        @Schema(description = "만족도")
-        byte satisfaction,
 
         @Schema(description = "메모")
         String memo,
@@ -42,10 +42,10 @@ public record ReviewCreateResponse(
                 .id(review.getId())
                 .aiPlanId(review.getAiPlan().getId())
                 .planId(review.getPlan().getId())
-                .mood(review.getMood())
                 .title(review.getTitle())
+                .description(review.getDescription())
+                .mood(review.getMood())
                 .achievement(review.getAchievement())
-                .satisfaction(review.getSatisfaction())
                 .memo(review.getMemo())
                 .createdAt(review.getCreatedAt())
                 .build();

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewDetailResponse.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.dto.response;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import dgu.umc_app.domain.review.entity.Mood;
 import dgu.umc_app.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,17 +28,18 @@ public record ReviewDetailResponse(
         @Schema(description = "회고 제목")
         String title,
 
+        @Schema(description = "회고 부제목")
+        String description,
+
         @Schema(description = "성취도")
         byte achievement,
-
-        @Schema(description = "만족도")
-        byte satisfaction,
 
         @Schema(description = "회고 메모")
         String memo,
 
         @Schema(description = "작성일시")
-        LocalDate createdAt
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt
 
 ) {
     public static ReviewDetailResponse from(Review review) {
@@ -47,10 +49,10 @@ public record ReviewDetailResponse(
                 .planId(review.getPlan().getId())
                 .mood(review.getMood())
                 .title(review.getTitle())
+                .description(review.getDescription())
                 .achievement(review.getAchievement())
-                .satisfaction(review.getSatisfaction())
                 .memo(review.getMemo())
-                .createdAt(review.getCreatedAt().toLocalDate())
+                .createdAt(review.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewListResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewListResponse.java
@@ -1,7 +1,7 @@
 package dgu.umc_app.domain.review.dto.response;
 
-import java.time.LocalDate;
-
+import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import dgu.umc_app.domain.review.entity.Review;
 import lombok.Builder;
 
@@ -9,15 +9,16 @@ import lombok.Builder;
 public record ReviewListResponse(
         Long reviewId,
         String title,
-        String memo,
-        LocalDate createdAt
+        String description,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime createdAt
 ) {
     public static ReviewListResponse from(Review review) {
         return ReviewListResponse.builder()
                 .reviewId(review.getId())
                 .title(review.getTitle())
-                .memo(review.getMemo())
-                .createdAt(review.getCreatedAt().toLocalDate())
+                .description(review.getDescription())
+                .createdAt(review.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/dgu/umc_app/domain/review/entity/Review.java
+++ b/src/main/java/dgu/umc_app/domain/review/entity/Review.java
@@ -27,7 +27,10 @@ public class Review extends BaseEntity {
     private Plan plan; // 일정 외래키 (id2에 해당)
 
     @Column(nullable = false, length = 50)
-    private String title;
+    private String title;       // Plan.title
+
+    @Column(nullable = false, length = 50)
+    private String description; // AiPlan.description
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -36,20 +39,17 @@ public class Review extends BaseEntity {
     @Column(nullable = false)
     private byte achievement; // 성취도
 
-    @Column(nullable = false)
-    private byte satisfaction; // 만족도
-
     @Column(nullable = false, length = 255)
     private String memo; // 2줄 정도의 회고 메모
 
     @Builder
-    public Review(AiPlan aiPlan, Plan plan, String title, Mood mood, byte achievement, byte satisfaction, String memo) {
+    public Review(AiPlan aiPlan, Plan plan, String title, String description, Mood mood, byte achievement, String memo) {
         this.aiPlan = aiPlan;
         this.plan = plan;
         this.title = title;
+        this.description = description;
         this.mood = mood;
         this.achievement = achievement;
-        this.satisfaction = satisfaction;
         this.memo = memo;
     }
 }

--- a/src/main/java/dgu/umc_app/domain/review/entity/Review.java
+++ b/src/main/java/dgu/umc_app/domain/review/entity/Review.java
@@ -52,4 +52,10 @@ public class Review extends BaseEntity {
         this.achievement = achievement;
         this.memo = memo;
     }
+
+    public void update(Mood mood, byte achievement, String memo) {
+        this.mood = mood;
+        this.achievement = achievement;
+        this.memo = memo;
+    }
 }

--- a/src/main/java/dgu/umc_app/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/review/exception/ReviewErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
 
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_3", "해당 회고가 존재하지 않습니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_3", "해당 회고가 존재하지 않습니다."),
+    REVIEW_NOT_FOUND_BY_DATE(HttpStatus.NOT_FOUND, "REVIEW404_4", "해당 날짜에 작성된 회고가 없습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     //날짜별 회고 갯수
@@ -31,5 +32,26 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     ORDER BY r.createdAt DESC
 """)
     List<Review> findAllByUserIdAndDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
+
+
+    //특정 날짜 검색으로 인한 회고 블럭 조회
+     @Query("""
+    SELECT new dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse(
+        CAST(r.createdAt AS date), COUNT(r)
+    )
+    FROM Review r
+    WHERE r.aiPlan.plan.user.id = :userId
+    AND CAST(r.createdAt AS date) = :targetDate
+    GROUP BY CAST(r.createdAt AS date)
+    """)
+    ReviewCountByDateResponse countByUserIdAndDate(@Param("userId") Long userId,
+                                                   @Param("targetDate") java.sql.Date targetDate);
+
+     //단일 회고 상세 조회
+     @Query("""
+    SELECT r FROM Review r
+    WHERE r.id = :reviewId AND r.aiPlan.plan.user.id = :userId
+""")
+     Optional<Review> findByIdAndUserId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
@@ -1,19 +1,35 @@
 package dgu.umc_app.domain.review.repository;
 
+import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+    //날짜별 회고 갯수
     @Query("""
-    select r
-    from Review r
-    where r.aiPlan.plan.user.id = :userId
-    order by r.createdAt desc
+    SELECT new dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse(
+        CAST(r.createdAt AS date), COUNT(r)
+    )
+    FROM Review r
+    WHERE r.aiPlan.plan.user.id = :userId
+    GROUP BY CAST(r.createdAt AS date)
+    ORDER BY CAST(r.createdAt AS date) DESC
 """)
-    List<Review> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+    List<ReviewCountByDateResponse> countReviewsByDate(@Param("userId") Long userId);
+
+    //특정 날짜의 회고 목록
+    @Query("""
+    SELECT r
+    FROM Review r
+    WHERE r.aiPlan.plan.user.id = :userId
+    AND DATE(r.createdAt) = :targetDate
+    ORDER BY r.createdAt DESC
+""")
+    List<Review> findAllByUserIdAndDate(@Param("userId") Long userId, @Param("targetDate") LocalDate targetDate);
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -28,8 +28,6 @@ public class ReviewCommandService {
 
     /**
      * 회고 저장
-     * @param request 회고 작성 요청 DTO
-     * @return 저장된 회고 ID
      */
     @Transactional
     public ReviewCreateResponse saveReview(ReviewCreateRequest request) {
@@ -39,11 +37,17 @@ public class ReviewCommandService {
         Plan plan = planRepository.findById(request.planId())
                 .orElseThrow(() -> BaseException.type(PlanErrorCode.PLAN_NOT_FOUND));
 
-        Review review = request.toEntity(aiPlan, plan);
-        Review saved = reviewRepository.save(review);
+        Review review = Review.builder()
+                .aiPlan(aiPlan)
+                .plan(plan)
+                .title(plan.getTitle())                   // Plan.title 복사
+                .description(aiPlan.getDescription())     // AiPlan.description 복사
+                .mood(request.mood())
+                .achievement((byte) request.achievement())
+                .memo(request.memo())
+                .build();
 
+        Review saved = reviewRepository.save(review);
         return ReviewCreateResponse.from(saved);
     }
-
-
 }

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -32,11 +32,12 @@ public class ReviewCommandService {
     /**
      * 회고 저장
      */
-    public ReviewCreateResponse saveReview(ReviewCreateRequest request) {
-        AiPlan aiPlan = aiPlanRepository.findById(request.aiPlanId())
+
+    public ReviewCreateResponse saveReview(Long userId, ReviewCreateRequest request) {
+        AiPlan aiPlan = aiPlanRepository.findByIdAndUserId(request.aiPlanId(), userId)
                 .orElseThrow(() -> BaseException.type(AiPlanErrorCode.AI_PLAN_NOT_FOUND));
 
-        Plan plan = planRepository.findById(request.planId())
+        Plan plan = planRepository.findByIdAndUserId(request.planId(), userId)
                 .orElseThrow(() -> BaseException.type(PlanErrorCode.PLAN_NOT_FOUND));
 
         Review review = Review.builder()

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -6,7 +6,9 @@ import dgu.umc_app.domain.ai_plan.repository.AiPlanRepository;
 import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.review.dto.request.ReviewCreateRequest;
+import dgu.umc_app.domain.review.dto.request.ReviewUpdateRequest;
 import dgu.umc_app.domain.review.dto.response.ReviewCreateResponse;
+import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
 import dgu.umc_app.domain.review.entity.Review;
 import dgu.umc_app.domain.review.exception.ReviewErrorCode;
 import dgu.umc_app.domain.plan.exception.PlanErrorCode;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ReviewCommandService {
 
     private final ReviewRepository reviewRepository;
@@ -29,7 +32,6 @@ public class ReviewCommandService {
     /**
      * 회고 저장
      */
-    @Transactional
     public ReviewCreateResponse saveReview(ReviewCreateRequest request) {
         AiPlan aiPlan = aiPlanRepository.findById(request.aiPlanId())
                 .orElseThrow(() -> BaseException.type(AiPlanErrorCode.AI_PLAN_NOT_FOUND));
@@ -50,4 +52,14 @@ public class ReviewCommandService {
         Review saved = reviewRepository.save(review);
         return ReviewCreateResponse.from(saved);
     }
+    /**
+     * 회고 수정
+     */
+    public ReviewDetailResponse updateReview(Long userId, Long reviewId, ReviewUpdateRequest request) {
+        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
+                .orElseThrow(() -> BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND));
+        review.update(request.mood(), (byte) request.achievement(), request.memo());
+        return ReviewDetailResponse.from(review);
+    }
+
 }

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
@@ -1,6 +1,7 @@
 package dgu.umc_app.domain.review.service;
 
 import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
+import dgu.umc_app.domain.review.dto.response.ReviewCountByDateResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewListResponse;
 import dgu.umc_app.domain.review.entity.Review;
 import dgu.umc_app.domain.review.exception.ReviewErrorCode;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -23,6 +25,13 @@ public class ReviewQueryService {
     private final UserRepository userRepository;
 
     /**
+     * 회고 목록(블럭별)조회 (내림차순)
+     */
+    public List<ReviewCountByDateResponse> getReviewCountByDate(Long userId) {
+        return reviewRepository.countReviewsByDate(userId);
+    }
+
+    /**
      * 단일 회고 상세 조회
      */
     public ReviewDetailResponse getReview(Long reviewId) {
@@ -32,17 +41,21 @@ public class ReviewQueryService {
     }
 
     /**
-     * 전체 회고 목록 조회 (최신순 정렬)
+     * 특정 날짜 회고 목록 조회 (최신순 정렬)
      */
-    public List<ReviewListResponse> getReviewListByUserId(Long userId) {
+    public List<ReviewListResponse> getReviewListByUserIdAndDate(Long userId, LocalDate date) {
         if (!userRepository.existsById(userId)) {
             throw BaseException.type(UserErrorCode.USER_NOT_FOUND);
         }
 
-        List<Review> reviews = reviewRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+        List<Review> reviews = reviewRepository.findAllByUserIdAndDate(userId, date);
+        if (reviews.isEmpty()) {
+            throw BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND_BY_DATE);
+        }
         return reviews.stream()
                 .map(ReviewListResponse::from)
                 .toList();
     }
+
 }
 

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -34,11 +35,12 @@ public class ReviewQueryService {
     /**
      * 단일 회고 상세 조회
      */
-    public ReviewDetailResponse getReview(Long reviewId) {
-        Review review = reviewRepository.findById(reviewId)
+    public ReviewDetailResponse getReview(Long userId, Long reviewId) {
+        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
                 .orElseThrow(() -> BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND));
         return ReviewDetailResponse.from(review);
     }
+
 
     /**
      * 특정 날짜 회고 목록 조회 (최신순 정렬)
@@ -55,6 +57,17 @@ public class ReviewQueryService {
         return reviews.stream()
                 .map(ReviewListResponse::from)
                 .toList();
+    }
+
+    /**
+     * 특정 날짜 검색으로 인한 회고 블럭 조회
+     */
+    public ReviewCountByDateResponse getReviewSearch(Long userId, LocalDate date) {
+        ReviewCountByDateResponse result = reviewRepository.countByUserIdAndDate(userId, Date.valueOf(date));
+        if (result == null) {
+            throw BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND_BY_DATE);
+        }
+        return result;
     }
 
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #57

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 회고 날짜 검색(검색 날짜, 회고 갯수 반환) API
- 회고 내용 수정 API

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
