### PR TITLE
[ feat ] FCM 토큰 삭제 API를 구현한다

### DIFF
--- a/src/main/java/dgu/umc_app/domain/fcm/entity/FcmErrorResponse.java
+++ b/src/main/java/dgu/umc_app/domain/fcm/entity/FcmErrorResponse.java
@@ -1,0 +1,39 @@
+package dgu.umc_app.domain.fcm.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FcmErrorResponse {
+    //토큰 삭제 필요 오류
+    UNREGISTERED(true),
+    INVALID_ARGUMENT(true),
+    NOT_FOUND(true),
+    SENDER_ID_MISMATCH(true),
+    INVALID_REGISTRATION(true),
+    REGISTRATION_TOKEN_NOT_REGISTERED(true),
+
+    // 일시적 요류 (토큰 유지)
+    UNAVAILABLE(false),
+    INTERNAL(false),
+    DEADLINE_EXCEEDED(false),
+    QUOTA_EXCEEDED(false),
+    UNKNOWN(false)
+    ;
+
+
+    private final boolean shouldDeleteToken;
+
+    public static FcmErrorResponse fromErrorCode(String errorCode){
+        if(errorCode == null)
+            return UNKNOWN;
+
+        try{
+            return FcmErrorResponse.valueOf(errorCode);
+        } catch(IllegalArgumentException e){
+            return UNKNOWN;
+        }
+    }
+
+}

--- a/src/main/java/dgu/umc_app/domain/fcm/entity/FcmToken.java
+++ b/src/main/java/dgu/umc_app/domain/fcm/entity/FcmToken.java
@@ -34,6 +34,6 @@ public class FcmToken extends BaseEntity {
 
     // == fcmToken 비활성화 및 활성화 메서드 ==/
     public void updateNotificationEnabled (boolean notificationEnabled) {
-        this.isActive = notificationEnabled;
+        this.notificationEnabled = notificationEnabled;
     }
 }

--- a/src/main/java/dgu/umc_app/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/dgu/umc_app/domain/fcm/repository/FcmTokenRepository.java
@@ -14,4 +14,5 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     Optional<FcmToken> findByUserAndDeviceId(User user, String deviceId);
 
+    Optional<FcmToken> findByToken(String token);
 }

--- a/src/main/java/dgu/umc_app/domain/fcm/service/FcmTokenCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/fcm/service/FcmTokenCommandService.java
@@ -1,14 +1,11 @@
 package dgu.umc_app.domain.fcm.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import dgu.umc_app.domain.plan.repository.AiPlanRepository;
 import dgu.umc_app.domain.fcm.dto.request.RegisterFcmTokenRequestDto;
 import dgu.umc_app.domain.fcm.dto.request.UpdateFcmNotificationRequestDto;
 import dgu.umc_app.domain.fcm.dto.response.RegisterTokenResponseDto;
 import dgu.umc_app.domain.fcm.entity.FcmToken;
 import dgu.umc_app.domain.fcm.exception.FcmErrorCode;
 import dgu.umc_app.domain.fcm.repository.FcmTokenRepository;
-import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +34,10 @@ public class FcmTokenCommandService {
         fcmToken.updateNotificationEnabled(request.enabled());
     }
 
+    @Transactional
+    public void deleteInvalidToken(String token){
+        fcmTokenRepository.findByToken(token)
+                .ifPresent(fcmTokenRepository::delete);
+    }
 
 }

--- a/src/main/java/dgu/umc_app/domain/fcm/service/FcmTokenQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/fcm/service/FcmTokenQueryService.java
@@ -1,7 +1,9 @@
 package dgu.umc_app.domain.fcm.service;
 
 import dgu.umc_app.domain.fcm.entity.FcmToken;
+import dgu.umc_app.domain.fcm.exception.FcmErrorCode;
 import dgu.umc_app.domain.fcm.repository.FcmTokenRepository;
+import dgu.umc_app.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,8 @@ public class FcmTokenQueryService {
                 .map(FcmToken::getToken)
                 .toList();
     }
+
+
 
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #67 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
- Fcm Token Error Response 관리
- ErrorResponse가 shouldDelete true시에 바로 삭제

## 📸 스크린샷 (선택)

## 📢 참고 사항
ErrorResponse가 delete되어야 하는 경우 scheduler로 일괄처리하는 것보단 그자리에서 즉시 삭제하는게 
더 나을 것 같아서 바로 삭제하도록 코드 작성했습니다

3시 15분으로 스케줄링 되었을 경우 -> 현재시간 3시14분에 서버가 꺼지고 3시16분에 서버가 다시 켜지면 울려야 하는 알림이 울리지않고
남아있는 상황 -> 재스케줄링 되었을 경우 과거의 schedule이기 때문에 예외가 발생하는 문제가 생기는데 
-> 이를 해결하기 위해 예외를 던지는 것이 아니라 스케줄링시 과거의 스케줄인 경우는 return으로 스케줄 하지 않는 방식으로 바꿨습니다
(예외처리X)  
