### PR TITLE
[feat] #76 토큰 재발급 api 구현 완료

### DIFF
--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
@@ -6,7 +6,9 @@ import dgu.umc_app.domain.user.dto.request.GoogleSignUpRequest;
 import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.UserSignupRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoSignUpRequest;
+import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.LoginUser;
@@ -125,4 +127,18 @@ public interface UserAuthApi {
         @ApiResponse(responseCode = "401", description = "로그아웃 실패")
     })
     void logout();
+
+    @Operation(
+        summary = "토큰 재발급",
+        description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급합니다. \n" +
+                "Refresh Token Rotation을 적용하여 보안을 강화합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = ReissueTokenResponse.class))),
+        @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰"),
+        @ApiResponse(responseCode = "400", description = "입력값 검증 실패")
+    })
+    ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request);
 } 

--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
@@ -11,9 +11,12 @@ import dgu.umc_app.domain.user.dto.request.UserSignupRequest;
 import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.GoogleLoginRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoLoginRequest;
+import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
 import dgu.umc_app.global.authorize.LoginUser;
+import dgu.umc_app.global.authorize.TokenService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class UserAuthController implements UserAuthApi {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+    private final TokenService tokenService;
     
     @PostMapping("/signup")
     public UserResponse signup(@Valid @RequestBody UserSignupRequest request) {
@@ -65,5 +69,10 @@ public class UserAuthController implements UserAuthApi {
     @PostMapping("/auth/logout")
     public void logout() {
         userCommandService.logout();
+    }
+
+    @PostMapping("/auth/reissue")
+    public ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request) {
+        return tokenService.reissueToken(request.refreshToken());
     }
 }

--- a/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
@@ -1,0 +1,13 @@
+package dgu.umc_app.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+    private final String accessToken;
+    private final String refreshToken;
+    private final long accessTokenExp;
+    private final long refreshTokenExp;
+}

--- a/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
@@ -1,13 +1,20 @@
 package dgu.umc_app.domain.user.dto;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class TokenDto {
-    private final String accessToken;
-    private final String refreshToken;
-    private final long accessTokenExp;
-    private final long refreshTokenExp;
+public record TokenDto(
+    String accessToken,
+    String refreshToken,
+    long accessTokenExp,
+    long refreshTokenExp
+) {
+    public static TokenDto of(String accessToken, String refreshToken, long accessTokenExp, long refreshTokenExp) {
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessTokenExp(accessTokenExp)
+                .refreshTokenExp(refreshTokenExp)
+                .build();
+    }
 }

--- a/src/main/java/dgu/umc_app/domain/user/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/request/ReissueTokenRequest.java
@@ -1,0 +1,9 @@
+package dgu.umc_app.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueTokenRequest(
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    String refreshToken
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/user/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,12 @@
+package dgu.umc_app.domain.user.dto.response;
+
+public record ReissueTokenResponse(
+    String accessToken,
+    String refreshToken,
+    String tokenType,
+    long expiresIn
+) {
+    public static ReissueTokenResponse of(String accessToken, String refreshToken, long expiresIn) {
+        return new ReissueTokenResponse(accessToken, refreshToken, "Bearer", expiresIn);
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/user/exception/AuthErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/user/exception/AuthErrorCode.java
@@ -10,9 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
     
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_1", "유효하지 않은 토큰입니다."),
-    ALREADY_COMPLETED_SIGNUP(HttpStatus.BAD_REQUEST, "AUTH400_2", "이미 회원가입이 완료된 사용자입니다."),
-    USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "사용자가 인증되지 않았습니다."),
-    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500_4", "로그아웃 처리 중 오류가 발생했습니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_2", "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_3", "리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_4", "리프레시 토큰이 일치하지 않습니다."),
+    
+    ALREADY_COMPLETED_SIGNUP(HttpStatus.BAD_REQUEST, "AUTH400_5", "이미 회원가입이 완료된 사용자입니다."),
+    USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "사용자가 인증되지 않았습니다."),
+    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500_7", "로그아웃 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/global/authorize/TokenService.java
+++ b/src/main/java/dgu/umc_app/global/authorize/TokenService.java
@@ -4,6 +4,8 @@ import dgu.umc_app.global.common.JwtUtil;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
+import dgu.umc_app.domain.user.repository.UserRepository;
 import dgu.umc_app.global.exception.BaseException;
 import dgu.umc_app.domain.user.exception.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.data.redis.core.RedisTemplate;
 import java.time.Duration;
+import dgu.umc_app.domain.user.dto.TokenDto;
 
 @Slf4j
 @Service
@@ -22,44 +25,42 @@ public class TokenService {
     
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
     
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
 
-    /**
-     * 토큰 발급 응답 생성 메서드들
-     */
-    public UserResponse issueTokenResponse(User user) {
+    // 공통 토큰 발급/저장 메서드
+    private TokenDto createAndStoreTokens(User user) {
+      
         Authentication authentication = createAuthentication(user);
-        
         String accessToken = jwtUtil.generateAccessToken(authentication);
         String refreshToken = jwtUtil.generateRefreshToken(authentication);
         long accessTokenExp = jwtUtil.getAccessTokenExpirationInSeconds();
         long refreshTokenExp = jwtUtil.getRefreshTokenExpirationInSeconds();
-
-        // 리프레시 토큰을 Redis에 저장
         saveRefreshToken(user.getId().toString(), refreshToken, refreshTokenExp);
+        
+        return TokenDto.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .accessTokenExp(accessTokenExp)
+            .refreshTokenExp(refreshTokenExp)
+            .build();
+    }
 
-        return UserResponse.of(accessToken, refreshToken, accessTokenExp, refreshTokenExp);
+    public UserResponse issueTokenResponse(User user) {
+        TokenDto token = createAndStoreTokens(user);
+        return UserResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp());
+    }
+
+    public AuthLoginResponse generateLoginTokens(User user, boolean isNewUser) {
+        TokenDto token = createAndStoreTokens(user);
+        return AuthLoginResponse.login(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp(), isNewUser);
     }
 
     public String generateTempTokenForUser(User user) {
         Authentication authentication = createAuthentication(user);
         return jwtUtil.generateTempToken(authentication);
-    }
-
-    public AuthLoginResponse generateLoginTokens(User user, boolean isNewUser) {
-        Authentication authentication = createAuthentication(user);
-        
-        String accessToken = jwtUtil.generateAccessToken(authentication);
-        String refreshToken = jwtUtil.generateRefreshToken(authentication);
-        long accessTokenExp = jwtUtil.getAccessTokenExpirationInSeconds();
-        long refreshTokenExp = jwtUtil.getRefreshTokenExpirationInSeconds();
-        
-        // 리프레시 토큰을 Redis에 저장
-        saveRefreshToken(user.getId().toString(), refreshToken, refreshTokenExp);
-        
-        return AuthLoginResponse.login(accessToken, refreshToken, accessTokenExp, refreshTokenExp, isNewUser);
     }
 
     // 인증 객체 생성
@@ -110,6 +111,52 @@ public class TokenService {
     // 블랙리스트 체크
     public boolean isTokenBlacklisted(String token) {
         return isBlacklisted(token);
+    }
+
+    // 토큰 재발급 (Refresh Token Rotation)
+    public ReissueTokenResponse reissueToken(String refreshToken) {
+        try {
+            if (!jwtUtil.validateToken(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            if (!jwtUtil.isRefreshToken(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            if (isBlacklisted(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+            String storedRefreshToken = getRefreshToken(userId.toString());
+            
+            if (storedRefreshToken == null) {
+                throw BaseException.type(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+            }
+            
+            if (!refreshToken.equals(storedRefreshToken)) {
+                throw BaseException.type(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+            }
+            
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> BaseException.type(AuthErrorCode.USER_NOT_AUTHENTICATED));
+            
+            // 기존 리프레시 토큰 삭제 (Refresh Token Rotation)
+            deleteRefreshToken(userId.toString());
+            
+            // 새 토큰 발급 및 저장
+            TokenDto token = createAndStoreTokens(user);
+            
+            log.info("토큰 재발급 완료: userId={}", userId);
+            
+            return ReissueTokenResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp());
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 재발급 중 오류 발생: {}", e.getMessage());
+            throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
     }
     
     // 액세스 토큰을 블랙리스트에 추가

--- a/src/main/java/dgu/umc_app/global/authorize/TokenService.java
+++ b/src/main/java/dgu/umc_app/global/authorize/TokenService.java
@@ -32,30 +32,22 @@ public class TokenService {
 
     // 공통 토큰 발급/저장 메서드
     private TokenDto createAndStoreTokens(User user) {
-      
         Authentication authentication = createAuthentication(user);
-        String accessToken = jwtUtil.generateAccessToken(authentication);
-        String refreshToken = jwtUtil.generateRefreshToken(authentication);
-        long accessTokenExp = jwtUtil.getAccessTokenExpirationInSeconds();
-        long refreshTokenExp = jwtUtil.getRefreshTokenExpirationInSeconds();
-        saveRefreshToken(user.getId().toString(), refreshToken, refreshTokenExp);
+        TokenDto tokenDto = jwtUtil.createTokenDto(authentication);
         
-        return TokenDto.builder()
-            .accessToken(accessToken)
-            .refreshToken(refreshToken)
-            .accessTokenExp(accessTokenExp)
-            .refreshTokenExp(refreshTokenExp)
-            .build();
+        saveRefreshToken(user.getId().toString(), tokenDto.refreshToken(), tokenDto.refreshTokenExp());
+        
+        return tokenDto;
     }
 
     public UserResponse issueTokenResponse(User user) {
         TokenDto token = createAndStoreTokens(user);
-        return UserResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp());
+        return UserResponse.of(token.accessToken(), token.refreshToken(), token.accessTokenExp(), token.refreshTokenExp());
     }
 
     public AuthLoginResponse generateLoginTokens(User user, boolean isNewUser) {
         TokenDto token = createAndStoreTokens(user);
-        return AuthLoginResponse.login(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp(), isNewUser);
+        return AuthLoginResponse.login(token.accessToken(), token.refreshToken(), token.accessTokenExp(), token.refreshTokenExp(), isNewUser);
     }
 
     public String generateTempTokenForUser(User user) {
@@ -150,7 +142,7 @@ public class TokenService {
             
             log.info("토큰 재발급 완료: userId={}", userId);
             
-            return ReissueTokenResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp());
+            return ReissueTokenResponse.of(token.accessToken(), token.refreshToken(), token.accessTokenExp());
         } catch (BaseException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/dgu/umc_app/global/common/JwtUtil.java
+++ b/src/main/java/dgu/umc_app/global/common/JwtUtil.java
@@ -6,6 +6,7 @@ import dgu.umc_app.global.authorize.CustomUserDetails;
 import dgu.umc_app.global.exception.BaseException;
 import dgu.umc_app.global.exception.CommonErrorCode;
 import dgu.umc_app.domain.user.exception.AuthErrorCode;
+import dgu.umc_app.domain.user.dto.TokenDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
@@ -145,5 +146,15 @@ public class JwtUtil {
             return header.substring(7);
         }
         throw BaseException.type(AuthErrorCode.INVALID_TOKEN);
+    }
+
+    public TokenDto createTokenDto(Authentication authentication) {
+        
+        String accessToken = generateAccessToken(authentication);
+        String refreshToken = generateRefreshToken(authentication);
+        long accessTokenExp = getAccessTokenExpirationInSeconds();
+        long refreshTokenExp = getRefreshTokenExpirationInSeconds();
+        
+        return TokenDto.of(accessToken, refreshToken, accessTokenExp, refreshTokenExp);
     }
 }

--- a/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
@@ -12,7 +12,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -50,6 +49,7 @@ public class SecurityConfig {
                                 "/api/auth/normal",
                                 "/api/auth/google",
                                 "/api/auth/kakao",
+                                "/api/auth/reissue",
                                 "/api/signup/duplicate",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #76 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 토큰 재발급 api 구현완료

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->
<img width="1336" height="1420" alt="image" src="https://github.com/user-attachments/assets/f7633df9-7eb7-4ecd-bc82-eceff762d89a" />


## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
refreshToken 1회용으로 관리하기 위해서 accessToken, refreshToken을 둘 다 재발급하는걸로 코드 작성했습니다.