### PR TITLE
[feat] #85 비밀번호 변경 & 사용자 탈퇴 api 구현

### DIFF
--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
@@ -6,7 +6,9 @@ import dgu.umc_app.domain.user.dto.request.GoogleSignUpRequest;
 import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.UserSignupRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoSignUpRequest;
+import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.LoginUser;
@@ -125,4 +127,18 @@ public interface UserAuthApi {
         @ApiResponse(responseCode = "401", description = "로그아웃 실패")
     })
     void logout();
+
+    @Operation(
+        summary = "토큰 재발급",
+        description = "리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급합니다. \n" +
+                "Refresh Token Rotation을 적용하여 보안을 강화합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                content = @Content(mediaType = "application/json",
+                        schema = @Schema(implementation = ReissueTokenResponse.class))),
+        @ApiResponse(responseCode = "401", description = "유효하지 않은 리프레시 토큰"),
+        @ApiResponse(responseCode = "400", description = "입력값 검증 실패")
+    })
+    ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request);
 } 

--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthApi.java
@@ -7,6 +7,7 @@ import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.UserSignupRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoSignUpRequest;
 import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
+import dgu.umc_app.domain.user.dto.request.ChangePasswordRequest;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
 import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
@@ -141,4 +142,30 @@ public interface UserAuthApi {
         @ApiResponse(responseCode = "400", description = "입력값 검증 실패")
     })
     ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request);
+
+    @Operation(
+        summary = "회원 탈퇴",
+        description = "현재 로그인한 사용자의 회원 탈퇴를 처리합니다. \n" +
+                "소프트 삭제 방식으로 처리되며, 모든 토큰이 무효화됩니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+        @ApiResponse(responseCode = "400", description = "이미 탈퇴한 사용자"),
+        @ApiResponse(responseCode = "401", description = "인증 실패"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    void withdrawUser(@LoginUser Long userId);
+
+    @Operation(
+        summary = "비밀번호 변경",
+        description = "현재 비밀번호를 확인하고 새 비밀번호로 변경합니다. \n" +
+                "비밀번호 변경 후 모든 토큰이 무효화되어 재로그인이 필요합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
+        @ApiResponse(responseCode = "400", description = "비밀번호 형식 오류 또는 현재 비밀번호와 동일"),
+        @ApiResponse(responseCode = "401", description = "현재 비밀번호 불일치"),
+        @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    void changePassword(@LoginUser Long userId, @Valid @RequestBody ChangePasswordRequest request);
 } 

--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
@@ -12,6 +12,7 @@ import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.GoogleLoginRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoLoginRequest;
 import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
+import dgu.umc_app.domain.user.dto.request.ChangePasswordRequest;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
 import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
@@ -74,5 +75,15 @@ public class UserAuthController implements UserAuthApi {
     @PostMapping("/auth/reissue")
     public ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request) {
         return tokenService.reissueToken(request.refreshToken());
+    }
+
+    @PostMapping("/auth/withdraw")
+    public void withdrawUser(@LoginUser Long userId) {
+        userCommandService.withdrawUser(userId);
+    }
+
+    @PatchMapping("/auth/password/change")
+    public void changePassword(@LoginUser Long userId, @Valid @RequestBody ChangePasswordRequest request) {
+        userCommandService.changePassword(userId, request.currentPassword(), request.newPassword());
     }
 }

--- a/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
+++ b/src/main/java/dgu/umc_app/domain/user/controller/UserAuthController.java
@@ -11,9 +11,12 @@ import dgu.umc_app.domain.user.dto.request.UserSignupRequest;
 import dgu.umc_app.domain.user.dto.request.UserLoginRequest;
 import dgu.umc_app.domain.user.dto.request.GoogleLoginRequest;
 import dgu.umc_app.domain.user.dto.request.KakaoLoginRequest;
+import dgu.umc_app.domain.user.dto.request.ReissueTokenRequest;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
 import dgu.umc_app.global.authorize.LoginUser;
+import dgu.umc_app.global.authorize.TokenService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ public class UserAuthController implements UserAuthApi {
 
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+    private final TokenService tokenService;
     
     @PostMapping("/signup")
     public UserResponse signup(@Valid @RequestBody UserSignupRequest request) {
@@ -65,5 +69,10 @@ public class UserAuthController implements UserAuthApi {
     @PostMapping("/auth/logout")
     public void logout() {
         userCommandService.logout();
+    }
+
+    @PostMapping("/auth/reissue")
+    public ReissueTokenResponse reissueToken(@Valid @RequestBody ReissueTokenRequest request) {
+        return tokenService.reissueToken(request.refreshToken());
     }
 }

--- a/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/TokenDto.java
@@ -1,0 +1,13 @@
+package dgu.umc_app.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TokenDto {
+    private final String accessToken;
+    private final String refreshToken;
+    private final long accessTokenExp;
+    private final long refreshTokenExp;
+}

--- a/src/main/java/dgu/umc_app/domain/user/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/request/ChangePasswordRequest.java
@@ -1,0 +1,12 @@
+package dgu.umc_app.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangePasswordRequest(
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
+    String currentPassword,
+    
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    String newPassword
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/user/dto/request/ReissueTokenRequest.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/request/ReissueTokenRequest.java
@@ -1,0 +1,9 @@
+package dgu.umc_app.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReissueTokenRequest(
+    @NotBlank(message = "리프레시 토큰은 필수입니다.")
+    String refreshToken
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/user/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/dgu/umc_app/domain/user/dto/response/ReissueTokenResponse.java
@@ -1,0 +1,12 @@
+package dgu.umc_app.domain.user.dto.response;
+
+public record ReissueTokenResponse(
+    String accessToken,
+    String refreshToken,
+    String tokenType,
+    long expiresIn
+) {
+    public static ReissueTokenResponse of(String accessToken, String refreshToken, long expiresIn) {
+        return new ReissueTokenResponse(accessToken, refreshToken, "Bearer", expiresIn);
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/user/entity/User.java
+++ b/src/main/java/dgu/umc_app/domain/user/entity/User.java
@@ -111,4 +111,10 @@ public class User extends BaseEntity {
         this.agreedPrivacyPolicy = agreedPrivacyPolicy != null ? agreedPrivacyPolicy : false;
         this.nickname = nickname;
     }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = encodedPassword;
+        this.lastPasswordChanged = LocalDateTime.now();
+        this.passwordExpired = false;
+    }
 }

--- a/src/main/java/dgu/umc_app/domain/user/exception/AuthErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/user/exception/AuthErrorCode.java
@@ -10,9 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements ErrorCode {
     
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_1", "유효하지 않은 토큰입니다."),
-    ALREADY_COMPLETED_SIGNUP(HttpStatus.BAD_REQUEST, "AUTH400_2", "이미 회원가입이 완료된 사용자입니다."),
-    USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "사용자가 인증되지 않았습니다."),
-    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500_4", "로그아웃 처리 중 오류가 발생했습니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_2", "유효하지 않은 리프레시 토큰입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_3", "리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_4", "리프레시 토큰이 일치하지 않습니다."),
+    
+    ALREADY_COMPLETED_SIGNUP(HttpStatus.BAD_REQUEST, "AUTH400_5", "이미 회원가입이 완료된 사용자입니다."),
+    USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "사용자가 인증되지 않았습니다."),
+    LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500_7", "로그아웃 처리 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/user/exception/UserErrorCode.java
@@ -12,7 +12,10 @@ public enum UserErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "해당 사용자가 존재하지 않습니다."),
     USER_EMAIL_EXIST(HttpStatus.CONFLICT, "USER409_2", "해당 이메일이 존재합니다."),
     USER_WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "USER401_3", "비밀번호가 틀립니다."),
-    INVALID_SOCIAL_TOKEN(HttpStatus.BAD_REQUEST, "USER400_4", "유효하지 않은 소셜 로그인 토큰입니다.");
+    USER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "USER400_4", "이미 탈퇴한 사용자입니다."),
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "USER400_5", "비밀번호 형식이 올바르지 않습니다."),
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "USER400_6", "새 비밀번호는 현재 비밀번호와 달라야 합니다."),
+    INVALID_SOCIAL_TOKEN(HttpStatus.BAD_REQUEST, "USER400_7", "유효하지 않은 소셜 로그인 토큰입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/global/authorize/TokenService.java
+++ b/src/main/java/dgu/umc_app/global/authorize/TokenService.java
@@ -4,6 +4,8 @@ import dgu.umc_app.global.common.JwtUtil;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.domain.user.dto.response.UserResponse;
 import dgu.umc_app.domain.user.dto.response.AuthLoginResponse;
+import dgu.umc_app.domain.user.dto.response.ReissueTokenResponse;
+import dgu.umc_app.domain.user.repository.UserRepository;
 import dgu.umc_app.global.exception.BaseException;
 import dgu.umc_app.domain.user.exception.AuthErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.data.redis.core.RedisTemplate;
 import java.time.Duration;
+import dgu.umc_app.domain.user.dto.TokenDto;
 
 @Slf4j
 @Service
@@ -22,44 +25,42 @@ public class TokenService {
     
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
     
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String REFRESH_TOKEN_PREFIX = "refresh_token:";
 
-    /**
-     * 토큰 발급 응답 생성 메서드들
-     */
-    public UserResponse issueTokenResponse(User user) {
+    // 공통 토큰 발급/저장 메서드
+    private TokenDto createAndStoreTokens(User user) {
+      
         Authentication authentication = createAuthentication(user);
-        
         String accessToken = jwtUtil.generateAccessToken(authentication);
         String refreshToken = jwtUtil.generateRefreshToken(authentication);
         long accessTokenExp = jwtUtil.getAccessTokenExpirationInSeconds();
         long refreshTokenExp = jwtUtil.getRefreshTokenExpirationInSeconds();
-
-        // 리프레시 토큰을 Redis에 저장
         saveRefreshToken(user.getId().toString(), refreshToken, refreshTokenExp);
+        
+        return TokenDto.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken)
+            .accessTokenExp(accessTokenExp)
+            .refreshTokenExp(refreshTokenExp)
+            .build();
+    }
 
-        return UserResponse.of(accessToken, refreshToken, accessTokenExp, refreshTokenExp);
+    public UserResponse issueTokenResponse(User user) {
+        TokenDto token = createAndStoreTokens(user);
+        return UserResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp());
+    }
+
+    public AuthLoginResponse generateLoginTokens(User user, boolean isNewUser) {
+        TokenDto token = createAndStoreTokens(user);
+        return AuthLoginResponse.login(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp(), token.getRefreshTokenExp(), isNewUser);
     }
 
     public String generateTempTokenForUser(User user) {
         Authentication authentication = createAuthentication(user);
         return jwtUtil.generateTempToken(authentication);
-    }
-
-    public AuthLoginResponse generateLoginTokens(User user, boolean isNewUser) {
-        Authentication authentication = createAuthentication(user);
-        
-        String accessToken = jwtUtil.generateAccessToken(authentication);
-        String refreshToken = jwtUtil.generateRefreshToken(authentication);
-        long accessTokenExp = jwtUtil.getAccessTokenExpirationInSeconds();
-        long refreshTokenExp = jwtUtil.getRefreshTokenExpirationInSeconds();
-        
-        // 리프레시 토큰을 Redis에 저장
-        saveRefreshToken(user.getId().toString(), refreshToken, refreshTokenExp);
-        
-        return AuthLoginResponse.login(accessToken, refreshToken, accessTokenExp, refreshTokenExp, isNewUser);
     }
 
     // 인증 객체 생성
@@ -110,6 +111,52 @@ public class TokenService {
     // 블랙리스트 체크
     public boolean isTokenBlacklisted(String token) {
         return isBlacklisted(token);
+    }
+
+    // 토큰 재발급 (Refresh Token Rotation)
+    public ReissueTokenResponse reissueToken(String refreshToken) {
+        try {
+            if (!jwtUtil.validateToken(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            if (!jwtUtil.isRefreshToken(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            if (isBlacklisted(refreshToken)) {
+                throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+            
+            Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+            String storedRefreshToken = getRefreshToken(userId.toString());
+            
+            if (storedRefreshToken == null) {
+                throw BaseException.type(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+            }
+            
+            if (!refreshToken.equals(storedRefreshToken)) {
+                throw BaseException.type(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+            }
+            
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> BaseException.type(AuthErrorCode.USER_NOT_AUTHENTICATED));
+            
+            // 기존 리프레시 토큰 삭제 (Refresh Token Rotation)
+            deleteRefreshToken(userId.toString());
+            
+            // 새 토큰 발급 및 저장
+            TokenDto token = createAndStoreTokens(user);
+            
+            log.info("토큰 재발급 완료: userId={}", userId);
+            
+            return ReissueTokenResponse.of(token.getAccessToken(), token.getRefreshToken(), token.getAccessTokenExp());
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("토큰 재발급 중 오류 발생: {}", e.getMessage());
+            throw BaseException.type(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
     }
     
     // 액세스 토큰을 블랙리스트에 추가

--- a/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
@@ -12,7 +12,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -50,6 +49,7 @@ public class SecurityConfig {
                                 "/api/auth/normal",
                                 "/api/auth/google",
                                 "/api/auth/kakao",
+                                "/api/auth/reissue",
                                 "/api/signup/duplicate",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/umc_app/global/config/SecurityConfig.java
@@ -55,7 +55,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/actuator/**"
                         ).permitAll()
-                        .requestMatchers("/api/auth/logout").authenticated()
+                        .requestMatchers("/api/auth/logout", "/api/auth/withdraw", "/api/auth/password/change").authenticated()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 );

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/miruni_test
     username: root
-    password: Rlaehgns10!
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/miruni_test
     username: root
-    password: 1234
+    password: Rlaehgns10!
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #85 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 비밀번호 변경 api 구현
- 사용자 탈퇴 api 구현

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->

일단은 소프트 삭제로 구현했는데 나중에 필요하다면 스케쥴러 삭제 추가하겠습니다!