### PR TITLE
[feat] #81 일반 일정 회고 저장 API 구현

### DIFF
--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -8,6 +8,7 @@ import dgu.umc_app.domain.review.dto.response.ReviewDetailResponse;
 import dgu.umc_app.domain.review.dto.response.ReviewListResponse;
 import dgu.umc_app.domain.review.service.ReviewCommandService;
 import dgu.umc_app.global.authorize.CustomUserDetails;
+import dgu.umc_app.global.authorize.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,34 +27,33 @@ public interface ReviewApi {
 
     @Operation(summary = "회고 작성 후 저장 API",
             description = "특정 일정에 대한 회고(기분, 성취도, 만족도, 메모 등)를 작성하고 저장합니다.")
-    ReviewCreateResponse createReview(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                             @RequestBody @Valid ReviewCreateRequest request);
+    ReviewCreateResponse createReview(@LoginUser Long userId, @RequestBody @Valid ReviewCreateRequest request);
 
     @Operation(summary = "날짜별 회고 목록 갯수 조회 API",
             description = "날짜에 작성된 회고의 갯수 목록을 날짜순으로 반환합니다.")
-    List<ReviewCountByDateResponse> getReviewCountByDate(@AuthenticationPrincipal CustomUserDetails userDetails);
+    List<ReviewCountByDateResponse> getReviewCountByDate(@LoginUser Long userId);
 
     @Operation(summary = "단일 회고 상세 조회 API", description = "작성된 회고의 상세 정보를 조회합니다.")
-    ReviewDetailResponse getReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId);
+    ReviewDetailResponse getReview(@LoginUser Long userId, @PathVariable Long reviewId);
 
     @Operation(summary = "특정 날짜의 회고 목록 조회 API", description = "현재 로그인한 사용자의 특정 날짜 회고 목록(날짜, 제목, 부제목)을 최신순으로 조회합니다.")
     List<ReviewListResponse> getReviewListByDate(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     );
 
     @Operation(summary = "특정 회고 날짜 검색 API", description = "검색된 날짜에 작성된 회고의 갯수를 조회합니다.")
     ReviewCountByDateResponse getReviewSearch(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     );
 
     @Operation(summary = "회고 수정 API", description = "회고의 내용을 수정합니다.(기분, 성취도, 메모)")
-    public ReviewDetailResponse updateReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ReviewDetailResponse updateReview(@LoginUser Long userId,
                                              @PathVariable Long reviewId,
                                              @RequestBody @Valid ReviewUpdateRequest request);
 
 
     @Operation(summary = "회고 삭제", description = "특정 회고를 삭제합니다.")
-    public Long deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId);
+    public Long deleteReview(@LoginUser Long userId, @PathVariable Long reviewId);
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewApi.java
@@ -55,5 +55,5 @@ public interface ReviewApi {
 
 
     @Operation(summary = "회고 삭제", description = "특정 회고를 삭제합니다.")
-    public Long deleteReview(@PathVariable Long reviewId);
+    public Long deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId);
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -81,7 +81,7 @@ public class ReviewController implements ReviewApi{
 
     //회고 삭제
     @DeleteMapping("/{reviewId}")
-    public Long deleteReview(@PathVariable Long reviewId) {
-        return reviewCommandService.deleteReview(reviewId);
+    public Long deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId) {
+        return reviewCommandService.deleteReview(userDetails.getId(),reviewId);
     }
 }

--- a/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
+++ b/src/main/java/dgu/umc_app/domain/review/controller/ReviewController.java
@@ -9,6 +9,7 @@ import dgu.umc_app.domain.review.dto.response.ReviewListResponse;
 import dgu.umc_app.domain.review.service.ReviewCommandService;
 import dgu.umc_app.domain.review.service.ReviewQueryService;
 import dgu.umc_app.global.authorize.CustomUserDetails;
+import dgu.umc_app.global.authorize.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -33,55 +34,52 @@ public class ReviewController implements ReviewApi{
 
      //회고 작성 후 저장
      @PostMapping
-     public ReviewCreateResponse createReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+     public ReviewCreateResponse createReview(@LoginUser Long userId,
                                               @RequestBody @Valid ReviewCreateRequest request) {
-         Long userId = userDetails.getId();
          return reviewCommandService.saveReview(userId, request);
      }
 
     //회고록 날짜별 갯수 조회
     @GetMapping("/countByDate")
-    public List<ReviewCountByDateResponse> getReviewCountByDate(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        return reviewQueryService.getReviewCountByDate(userDetails.getUser().getId());
+    public List<ReviewCountByDateResponse> getReviewCountByDate(@LoginUser Long userId) {
+        return reviewQueryService.getReviewCountByDate(userId);
     }
 
     //개별 회고 상세 조회
     @GetMapping("/{reviewId}")
-    public ReviewDetailResponse getReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ReviewDetailResponse getReview(@LoginUser Long userId,
                                           @PathVariable Long reviewId) {
-        return reviewQueryService.getReview(userDetails.getId(), reviewId);
+        return reviewQueryService.getReview(userId, reviewId);
     }
 
 
     // 특정 날짜의 회고 목록 조회
     @GetMapping("/date")
-    public List<ReviewListResponse> getReviewListByDate(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+    public List<ReviewListResponse> getReviewListByDate(@LoginUser Long userId,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        return reviewQueryService.getReviewListByUserIdAndDate(userDetails.getId(), date);
+        return reviewQueryService.getReviewListByUserIdAndDate(userId, date);
     }
 
     //날짜 검색으로 인한 회고 블럭 조회
     @GetMapping("/search")
-    public ReviewCountByDateResponse getReviewSearch(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+    public ReviewCountByDateResponse getReviewSearch( @LoginUser Long userId,
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
-        return reviewQueryService.getReviewSearch(userDetails.getUser().getId(), date);
+        return reviewQueryService.getReviewSearch(userId, date);
     }
 
     //회고 수정
     @PatchMapping("/update/{reviewId}")
-    public ReviewDetailResponse updateReview(@AuthenticationPrincipal CustomUserDetails userDetails,
+    public ReviewDetailResponse updateReview(@LoginUser Long userId,
                                              @PathVariable Long reviewId,
                                              @RequestBody @Valid ReviewUpdateRequest request) {
-        return reviewCommandService.updateReview(userDetails.getId(), reviewId, request);
+        return reviewCommandService.updateReview(userId, reviewId, request);
     }
 
     //회고 삭제
     @DeleteMapping("/{reviewId}")
-    public Long deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId) {
-        return reviewCommandService.deleteReview(userDetails.getId(),reviewId);
+    public Long deleteReview(@LoginUser Long userId, @PathVariable Long reviewId) {
+        return reviewCommandService.deleteReview(userId,reviewId);
     }
 }

--- a/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,11 +1,12 @@
 package dgu.umc_app.domain.review.dto.request;
 
 import dgu.umc_app.domain.review.entity.Mood;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 public record ReviewCreateRequest(
 
-        @NotNull(message = "aiPlanId는 필수입니다.")
+        @Schema(description = "AI 계획 ID (일반 Plan 회고인 경우 null)")
         Long aiPlanId,
 
         @NotNull(message = "planId는 필수입니다.")

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewCreateResponse.java
@@ -40,7 +40,7 @@ public record ReviewCreateResponse(
     public static ReviewCreateResponse from(Review review) {
         return ReviewCreateResponse.builder()
                 .id(review.getId())
-                .aiPlanId(review.getAiPlan().getId())
+                .aiPlanId(review.getAiPlan() != null ? review.getAiPlan().getId() : null)
                 .planId(review.getPlan().getId())
                 .title(review.getTitle())
                 .description(review.getDescription())

--- a/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/dgu/umc_app/domain/review/dto/response/ReviewDetailResponse.java
@@ -45,7 +45,7 @@ public record ReviewDetailResponse(
     public static ReviewDetailResponse from(Review review) {
         return ReviewDetailResponse.builder()
                 .id(review.getId())
-                .aiPlanId(review.getAiPlan().getId())
+                .aiPlanId(review.getAiPlan() != null ? review.getAiPlan().getId() : null)
                 .planId(review.getPlan().getId())
                 .mood(review.getMood())
                 .title(review.getTitle())

--- a/src/main/java/dgu/umc_app/domain/review/entity/Review.java
+++ b/src/main/java/dgu/umc_app/domain/review/entity/Review.java
@@ -19,7 +19,7 @@ public class Review extends BaseEntity {
     private Long id; // 회고 아이디 (PK, auto_increment)
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ai_plan_id", nullable = false)
+    @JoinColumn(name = "ai_plan_id", nullable = true)
     private AiPlan aiPlan; // AI 계획 외래키
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
@@ -48,10 +48,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
                                                    @Param("targetDate") java.sql.Date targetDate);
 
      //단일 회고 상세 조회
-     @Query("""
-    SELECT r FROM Review r
-    WHERE r.id = :reviewId AND r.plan.user.id = :userId
-""")
-     Optional<Review> findByIdAndUserId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
+     Optional<Review> findByIdAndPlanUserId(Long id, Long userId);
 
 }

--- a/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
@@ -27,7 +27,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("""
     SELECT r
     FROM Review r
-    WHERE r.aiPlan.plan.user.id = :userId
+    WHERE r.plan.user.id = :userId
     AND DATE(r.createdAt) = :targetDate
     ORDER BY r.createdAt DESC
 """)
@@ -40,7 +40,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         CAST(r.createdAt AS date), COUNT(r)
     )
     FROM Review r
-    WHERE r.aiPlan.plan.user.id = :userId
+    WHERE r.plan.user.id = :userId
     AND CAST(r.createdAt AS date) = :targetDate
     GROUP BY CAST(r.createdAt AS date)
     """)
@@ -50,7 +50,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
      //단일 회고 상세 조회
      @Query("""
     SELECT r FROM Review r
-    WHERE r.id = :reviewId AND r.aiPlan.plan.user.id = :userId
+    WHERE r.id = :reviewId AND r.plan.user.id = :userId
 """)
      Optional<Review> findByIdAndUserId(@Param("reviewId") Long reviewId, @Param("userId") Long userId);
 

--- a/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/dgu/umc_app/domain/review/repository/ReviewRepository.java
@@ -17,7 +17,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         CAST(r.createdAt AS date), COUNT(r)
     )
     FROM Review r
-    WHERE r.aiPlan.plan.user.id = :userId
+    WHERE r.plan.user.id = :userId
     GROUP BY CAST(r.createdAt AS date)
     ORDER BY CAST(r.createdAt AS date) DESC
 """)

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -34,17 +34,26 @@ public class ReviewCommandService {
      */
 
     public ReviewCreateResponse saveReview(Long userId, ReviewCreateRequest request) {
-        AiPlan aiPlan = aiPlanRepository.findByIdAndUserId(request.aiPlanId(), userId)
-                .orElseThrow(() -> BaseException.type(AiPlanErrorCode.AIPLAN_NOT_FOUND));
-
         Plan plan = planRepository.findByIdWithUserId(request.planId(), userId)
                 .orElseThrow(() -> BaseException.type(PlanErrorCode.PLAN_NOT_FOUND));
+
+        AiPlan aiPlan = null;
+        String description;
+
+        if (request.aiPlanId() != null) {
+            aiPlan = aiPlanRepository.findByIdAndUserId(request.aiPlanId(), userId)
+                    .orElseThrow(() -> BaseException.type(AiPlanErrorCode.AIPLAN_NOT_FOUND));
+
+            description = aiPlan.getDescription();  // AI 일정 설명
+        } else {
+            description = plan.getDescription();  // 일반 일정 설명
+        }
 
         Review review = Review.builder()
                 .aiPlan(aiPlan)
                 .plan(plan)
                 .title(plan.getTitle())                   // Plan.title 복사
-                .description(aiPlan.getDescription())     // AiPlan.description 복사
+                .description(description)     // AiPlan or Plan description 복사
                 .mood(request.mood())
                 .achievement((byte) request.achievement())
                 .memo(request.memo())

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -66,7 +66,7 @@ public class ReviewCommandService {
      * 회고 수정
      */
     public ReviewDetailResponse updateReview(Long userId, Long reviewId, ReviewUpdateRequest request) {
-        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
+        Review review = reviewRepository.findByIdAndPlanUserId(reviewId, userId)
                 .orElseThrow(() -> BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND));
         review.update(request.mood(), (byte) request.achievement(), request.memo());
         return ReviewDetailResponse.from(review);
@@ -75,7 +75,7 @@ public class ReviewCommandService {
      * 회고 삭제
      */
     public Long deleteReview(Long userId, Long reviewId) {
-        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
+        Review review = reviewRepository.findByIdAndPlanUserId(reviewId, userId)
                 .orElseThrow(() -> new BaseException(ReviewErrorCode.REVIEW_NOT_FOUND));
         reviewRepository.delete(review);
         return reviewId;

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -74,8 +74,8 @@ public class ReviewCommandService {
     /**
      * 회고 삭제
      */
-    public Long deleteReview(Long reviewId) {
-        Review review = reviewRepository.findById(reviewId)
+    public Long deleteReview(Long userId, Long reviewId) {
+        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
                 .orElseThrow(() -> new BaseException(ReviewErrorCode.REVIEW_NOT_FOUND));
         reviewRepository.delete(review);
         return reviewId;

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewQueryService.java
@@ -36,7 +36,7 @@ public class ReviewQueryService {
      * 단일 회고 상세 조회
      */
     public ReviewDetailResponse getReview(Long userId, Long reviewId) {
-        Review review = reviewRepository.findByIdAndUserId(reviewId, userId)
+        Review review = reviewRepository.findByIdAndPlanUserId(reviewId, userId)
                 .orElseThrow(() -> BaseException.type(ReviewErrorCode.REVIEW_NOT_FOUND));
         return ReviewDetailResponse.from(review);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #81
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
- 일반 일정에 대한 회고 저장 API 구현
- 날짜별 회고록 갯수 조회 API 수정
- 회고 검색, 특정 날짜 회고 목록 조회, 단일 회고 상세 조회 API 수정
- 본인 회고만 삭제 가능하도록 인증 로직 추가

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
