### PR TITLE
[feat] 일정별 세부 조회 API

### DIFF
--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
@@ -62,4 +62,13 @@ public interface PlanApi {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
+    @Operation(
+            summary = "일정별 세부 조회 API",
+            description = "일정별 세부정보를 조회합니다."
+    )
+    PlanDetailResponse getPlanDetail(
+            @PathVariable Long planId,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
 }

--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
@@ -5,6 +5,7 @@ import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
 import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.domain.plan.service.PlanCommandService;
 import dgu.umc_app.domain.plan.service.PlanQueryService;
+import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,14 @@ public class PlanController implements PlanApi{
     ) {
         log.info("현재 로그인된 사용자 ID: {}", userDetails.getUser().getId()); // 이 로그로 확인
         return planCommandService.splitPlan(planId, request, userDetails.getUser());
+    }
+
+    @GetMapping("/{planId}")
+    public PlanDetailResponse getPlanDetail(
+            @PathVariable Long planId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return planQueryService.getPlanDetail(planId, userDetails.getUser().getId());
     }
 
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanCreateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanCreateRequest.java
@@ -26,6 +26,10 @@ public record PlanCreateRequest(
         @Schema(description = "수행 시작 날짜")
         LocalDateTime scheduledStart,
 
+        @NotNull(message = "수행 종료 날짜는 필수입니다.")
+        @Schema(description = "수행 종료 날짜")
+        LocalDateTime scheduledEnd,
+
         @Schema(description = "우선순위")
         Priority priority,
 
@@ -40,6 +44,7 @@ public record PlanCreateRequest(
                 .description(description)
                 .deadline(deadline)
                 .scheduledStart(scheduledStart)
+                .scheduledEnd(scheduledEnd)
                 .priority(priority)
                 .isDone(false)
                 .planCategory(PlanCategory.BASIC)

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetail.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetail.java
@@ -1,0 +1,25 @@
+package dgu.umc_app.domain.plan.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record PlanDetail(
+
+        @Schema(description = "일정 수행 시작 날짜")
+        LocalDate date,
+
+        @Schema(description = "할 일")
+        String description,
+
+        @Schema(description = "예상 소요 시간")
+        Long expectedDuration,
+
+        @Schema(description = "예상 시작 시간")
+        LocalTime scheduledStartTime,
+
+        @Schema(description = "예상 종료 시간")
+        LocalTime scheduledEndTime
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetailResponse.java
@@ -1,0 +1,68 @@
+package dgu.umc_app.domain.plan.dto.response;
+
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.Plan;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PlanDetailResponse(
+
+        @Schema(description = "일정 제목")
+        String title,
+
+        @Schema(description = "마감기한")
+        LocalDateTime deadline,
+
+        @Schema(description = "일정 범위")
+        String taskRange,
+
+        @Schema(description = "우선 순위")
+        String priority,
+
+        @Schema(description = "상세 일정 리스트")
+        List<PlanDetail> plans
+) {
+    public static PlanDetailResponse fromPlan(Plan plan) {
+        long expectedDuration = Duration.between(
+                plan.getScheduledStart().toLocalTime(),
+                plan.getScheduledEnd().toLocalTime()
+        ).toMinutes();
+
+        return new PlanDetailResponse(
+                plan.getTitle(),
+                plan.getDeadline(),
+                "", // 일반일정은 range 없음
+                plan.getPriority().name(),
+                List.of(new PlanDetail(
+                        plan.getScheduledStart().toLocalDate(),
+                        plan.getDescription(),
+                        expectedDuration,
+                        plan.getScheduledStart().toLocalTime(),
+                        plan.getScheduledEnd().toLocalTime()
+                ))
+        );
+    }
+
+    public static PlanDetailResponse fromAiPlan(Plan plan, List<AiPlan> aiPlans) {
+        List<PlanDetail> details = aiPlans.stream()
+                .map(ai -> new PlanDetail(
+                        ai.getScheduledStart().toLocalDate(),
+                        ai.getDescription(),
+                        ai.getExpectedDuration(),
+                        ai.getScheduledStart().toLocalTime(),
+                        ai.getScheduledEnd().toLocalTime()
+                ))
+                .toList();
+
+        return new PlanDetailResponse(
+                plan.getTitle(),
+                plan.getDeadline(),
+                aiPlans.get(0).getTaskRange(),
+                plan.getPriority().name(),
+                details
+        );
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
+++ b/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
@@ -39,9 +39,8 @@ public class Plan extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime scheduledStart; // 수행시작 예정 날짜&시간(ex: 2025-05-01T21:00:00)
 
-    // 일반 일정은 마감기한이 있으므로 deadline으로 대체(추후에 기획팀과 논의 후 처리)
-//    @Column(nullable = false)
-//    private LocalDateTime scheduledEnd; // 수행끝 예정 날짜&시간(ex: 2025-05-01T22:00:00)
+    @Column(nullable = false)
+    private LocalDateTime scheduledEnd; // 수행끝 예정 날짜&시간(ex: 2025-05-01T22:00:00)
 
     @Column(nullable = false)
     private boolean isDone; // 완료 체크

--- a/src/main/java/dgu/umc_app/domain/plan/repository/AiPlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/AiPlanRepository.java
@@ -21,4 +21,6 @@ public interface AiPlanRepository extends JpaRepository<AiPlan, Long> {
 """)
     Optional<AiPlan> findByIdAndUserId(@Param("aiPlanId") Long aiPlanId, @Param("userId") Long userId);
 
+    List<AiPlan> findByPlanId(Long planId); // 일정별 세부 조회
+
 }

--- a/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
-    Optional<Plan> findByIdAndUserId(Long id, Long userId);
     List<Plan> findByUserIdAndScheduledStartBetween(Long userId, LocalDateTime start, LocalDateTime end); //월별,일자별 조회
     List<Plan> findByUserIdAndIsDelayedTrue(Long userId);   //미룬 일정 조회
 

--- a/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/dgu/umc_app/domain/plan/repository/PlanRepository.java
@@ -24,7 +24,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     SELECT p FROM Plan p
     WHERE p.id = :planId AND p.user.id = :userId
 """)
-    Optional<Plan> findByIdAndUserId(@Param("planId") Long planId, @Param("userId") Long userId);
+    Optional<Plan> findByIdWithUserId(@Param("planId") Long planId, @Param("userId") Long userId);
 
     List<Plan> findByUserIdAndIsDoneFalseAndIsDelayedFalse(Long userId);    // 안 한 일정 조회
 

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
@@ -46,7 +46,7 @@ public class PlanCommandService {
     public List<PlanSplitResponse> splitPlan(Long planId, PlanSplitRequest request, User user) {
 
         // 1. 임시로 등록된 plan 조회하기
-        Plan plan = planRepository.findByIdAndUserId(planId, user.getId())
+        Plan plan = planRepository.findByIdWithUserId(planId, user.getId())
                 .orElseThrow(() -> new BaseException(PlanErrorCode.PLAN_NOT_FOUND));
 
         // 2. AI 분할 요청

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
@@ -1,15 +1,14 @@
 package dgu.umc_app.domain.plan.service;
 
+import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.domain.plan.entity.PlanCategory;
+import dgu.umc_app.domain.plan.exception.PlanErrorCode;
 import dgu.umc_app.domain.plan.repository.AiPlanRepository;
-import dgu.umc_app.domain.plan.dto.response.CalendarDayResponse;
-import dgu.umc_app.domain.plan.dto.response.CalendarDayWrapperResponse;
-import dgu.umc_app.domain.plan.dto.response.CalendarMonthResponse;
-import dgu.umc_app.domain.plan.dto.response.DelayedPlanResponse;
 import dgu.umc_app.domain.plan.entity.Plan;
 import dgu.umc_app.domain.plan.entity.AiPlan;
 import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.user.entity.User;
+import dgu.umc_app.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +17,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -93,7 +93,8 @@ public class PlanQueryService{
 
         result.sort(Comparator.comparing(CalendarDayResponse::startTime, Comparator.nullsLast(Comparator.naturalOrder())));
 
-        int totalCount = plans.size() + aiPlans.size();
+        int totalCount = (int) plans.stream().filter(plan -> !plan.isDone()).count()
+                + (int) aiPlans.stream().filter(aiPlan -> !aiPlan.isDone()).count();    // 안 한 일정 갯수로 변경
 
         return new CalendarDayWrapperResponse(totalCount, result);
     }
@@ -111,5 +112,21 @@ public class PlanQueryService{
         return result;
     }
 
-}
+    public PlanDetailResponse getPlanDetail(Long planId, Long userId) {
+        // 1. Plan 조회
+        Plan plan = planRepository.findByIdAndUserId(planId, userId)
+                .orElseThrow(() -> new BaseException(PlanErrorCode.PLAN_NOT_FOUND));
 
+        // 2. 해당 Plan이 AI 일정인지 확인
+        List<AiPlan> aiPlans = aiPlanRepository.findByPlanId(planId);
+
+        if (!aiPlans.isEmpty()) {
+            // AI 일정이면
+            return PlanDetailResponse.fromAiPlan(plan, aiPlans);
+        }
+
+        // 일반 일정이면
+        return PlanDetailResponse.fromPlan(plan);
+    }
+
+}

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
@@ -137,7 +137,7 @@ public class PlanQueryService{
 
     public PlanDetailResponse getPlanDetail(Long planId, Long userId) {
         // 1. Plan 조회
-        Plan plan = planRepository.findByIdAndUserId(planId, userId)
+        Plan plan = planRepository.findByIdWithUserId(planId, userId)
                 .orElseThrow(() -> new BaseException(PlanErrorCode.PLAN_NOT_FOUND));
 
         // 2. 해당 Plan이 AI 일정인지 확인

--- a/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/review/service/ReviewCommandService.java
@@ -17,6 +17,7 @@ import dgu.umc_app.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import dgu.umc_app.domain.review.exception.ReviewErrorCode;
 
 
 @Service

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,9 +2,13 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:3306/miruni_test
     username: root
-    password: Rlaehgns10!
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
+
+perplexity:
+  api-key: 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
+  api-url: https://api.perplexity.ai/chat/completions


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #65 
<!-- 이슈 완료되었을 때만 close 붙여주세요 --> 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 일정별 세부 조회 API 구현
- 일정 생성 request 수정(일정 수행 날짜에서 기간으로 변경)

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
yml 파일을 제외한 채로 dev에서 pull하는 것이 제한되어 yml 임시저장 커밋이 푸쉬가 되었네요!ㅠ