### PR TITLE
[feat] #116 일정 상태 완료 변경 API 구현

### DIFF
--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
@@ -1,11 +1,10 @@
 package dgu.umc_app.domain.plan.controller;
 
-import dgu.umc_app.domain.plan.dto.request.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanDelayRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanUpdateRequest;
+import dgu.umc_app.domain.plan.dto.request.*;
 import dgu.umc_app.domain.plan.dto.response.*;
+import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.CustomUserDetails;
+import dgu.umc_app.global.authorize.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -88,9 +87,19 @@ public interface PlanApi {
             summary = "일정별 세부 조회 API",
             description = "일정별 세부정보를 조회합니다."
     )
+    @GetMapping("/{planId}")
     PlanDetailResponse getPlanDetail(
             @PathVariable Long planId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+    @Operation(summary = "일정 상태 완료 변경", description = "일정의 상태를 '완료'로 변경하고 땅콩 개수를 반환합니다.")
+    @PatchMapping("/{planId}/finished")
+    PlanFinishResponse finishPlan(
+            @PathVariable Long planId,
+            @RequestBody @Valid PlanFinishRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            );
+
 
 }

--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
@@ -1,9 +1,6 @@
 package dgu.umc_app.domain.plan.controller;
 
-import dgu.umc_app.domain.plan.dto.request.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanDelayRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanUpdateRequest;
+import dgu.umc_app.domain.plan.dto.request.*;
 import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.domain.plan.entity.Category;
 import dgu.umc_app.domain.plan.repository.AiPlanRepository;
@@ -12,6 +9,7 @@ import dgu.umc_app.domain.plan.service.PlanCommandService;
 import dgu.umc_app.domain.plan.service.PlanQueryService;
 import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.CustomUserDetails;
+import dgu.umc_app.global.authorize.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -108,6 +106,15 @@ public class PlanController implements PlanApi{
                 ? planCommandService.delayAiPlan(planId, request, userDetails.getUser())
                 : planCommandService.delayPlan(planId, request, userDetails.getUser());
 
+    }
+
+    @PatchMapping("/{planId}/finished")
+    public PlanFinishResponse finishPlan(
+            @PathVariable Long planId,
+            @RequestBody @Valid PlanFinishRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+            ){
+        return planCommandService.finishPlanOrAiPlan(planId, request, userDetails.getUser());
     }
 
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanFinishRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanFinishRequest.java
@@ -1,0 +1,22 @@
+package dgu.umc_app.domain.plan.dto.request;
+
+import dgu.umc_app.domain.plan.entity.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record PlanFinishRequest(
+      @Schema(description = "BASIC or AI")
+      @NotNull
+      Category category,
+
+      @Schema(description = "수행한 시간")
+      @NotNull
+      int executeTime,
+
+      @Schema(description = "실제로 수행 시작한 시각")
+      @NotNull
+      LocalDateTime actualStart
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanFinishResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanFinishResponse.java
@@ -1,0 +1,46 @@
+package dgu.umc_app.domain.plan.dto.response;
+
+import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.Plan;
+import dgu.umc_app.domain.plan.entity.Status;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record PlanFinishResponse(
+
+        @Schema(description = "일정 아이디")
+        Long planId,
+
+        @Schema(description = "일정 상태")
+        Status status,
+
+        @Schema(description = "땅콩 개수")
+        int peanutCount,
+
+        @Schema(description = "일정 수행 시작 날짜")
+        LocalDateTime scheduledStart,
+
+        @Schema(description = "일정 수행 종료 날짜")
+        LocalDateTime scheduledEnd
+) {
+    public static PlanFinishResponse from(Plan plan, int peanutCount) {
+        return new PlanFinishResponse(
+                plan.getId(),
+                plan.getStatus(),
+                peanutCount,
+                plan.getScheduledStart(),
+                plan.getScheduledEnd()
+        );
+    }
+
+    public static PlanFinishResponse from(AiPlan aiplan, int peanutCount) {
+        return new PlanFinishResponse(
+                aiplan.getId(),
+                aiplan.getStatus(),
+                peanutCount,
+                aiplan.getScheduledStart(),
+                aiplan.getScheduledEnd()
+        );
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/plan/exception/PlanErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/plan/exception/PlanErrorCode.java
@@ -9,9 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlanErrorCode implements ErrorCode {
 
-    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "PLAN400_1", "시작일은 종료일보다 이전이어야 합니다."),
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404_1", "해당 일정이 존재하지 않습니다."),
-    INVALID_CATEGORY(HttpStatus.NOT_FOUND, "PLAN404_2", "해당 카테고리가 존재하지 않습니다.");
+    INVALID_CATEGORY(HttpStatus.NOT_FOUND, "PLAN404_2", "해당 카테고리가 존재하지 않습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "PLAN400_1", "시작일은 종료일보다 이전이어야 합니다."),
+    INVALID_EXECUTE_MINUTES(HttpStatus.BAD_REQUEST, "PLAN400_2", "수행시간 입력값이 음수입니다."),
+    ACTUAL_START_REQUIRED(HttpStatus.BAD_REQUEST, "PLAN400_3", "시작시간은 필수값입니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/domain/user/entity/User.java
+++ b/src/main/java/dgu/umc_app/domain/user/entity/User.java
@@ -56,10 +56,10 @@ public class User extends BaseEntity {
     @Builder.Default
     private int peanutCount = 0;
 
-    @Column
+    @Column(name = "delay_time")
     private int delayTime = 0; // 총 미룬 시간
 
-    @Column
+    @Column(name = "execute_time")
     private int executeTime = 0;  // 총 실행시간
 
     @ElementCollection(fetch = FetchType.LAZY)
@@ -219,8 +219,9 @@ public class User extends BaseEntity {
         return this.delayLevel;
     }
 
-    public void updateDelayTimes(int delayTimes) {this.delayTime = delayTime;}
-    public void updateExecuteTimes(int executeTimes) {this.executeTime = executeTime;}
+    public void updateDelayTime(int delayTime) {this.delayTime = delayTime;}
+    public void updateExecuteTime(int executeTime) {this.executeTime = executeTime;}
     public void updateDelayList(List<Long> delayTimeSlots) {this.delayList = delayTimeSlots;}
     public void updateFocusList(List<Long> focusSlots) {this.focusList = focusSlots;}
+    public void updatePeanutCount(int peanutCount) {this.peanutCount = peanutCount;}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #116 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- status = FINISHED 로 변경
- 수행시간, 집중 시간대 계산
- 땅콩 개수 계산해서 반환

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
