### PR TITLE
[refactor] 일정 수정/조회 dto 분리

### DIFF
--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanApi.java
@@ -1,13 +1,13 @@
 package dgu.umc_app.domain.plan.controller;
 
-import dgu.umc_app.domain.plan.dto.request.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanDelayRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanUpdateRequest;
+import dgu.umc_app.domain.plan.dto.request.*;
 import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.global.authorize.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,8 +37,12 @@ public interface PlanApi {
     );
 
     @Operation(summary = "미룬 일정 조회", description = "수행날짜가 지났지만 완료되지 않은 일정을 조회합니다.")
-    @GetMapping("/delayed")
-    List<DelayedPlanResponse> getDelayedPlans(
+    List<PausedPlanResponse> getDelayedPlans(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "안 한 일정 조회", description = "미루지도 않고 수행하지도 않은 일정을 조회합니다.")
+    List<UnstartedPlanResponse> getUnstartedPlans(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
@@ -61,14 +65,7 @@ public interface PlanApi {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "안 한 일정 조회", description = "미루지도 않고 수행하지도 않은 일정을 조회합니다.")
-    @GetMapping("/unfinished")
-    List<UnstartedPlanResponse> getUnfinishedPlans(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
-    );
-
     @Operation(summary = "일정 미루기 API", description = "일정을 수행하다가 수행예정 날짜와 소요시간을 설정해 미룹니다.")
-    @PatchMapping("/{planId}/delay")
     PlanDelayResponse delayPlan(
             @PathVariable Long planId,
             @RequestBody @Valid PlanDelayRequest request,
@@ -76,10 +73,67 @@ public interface PlanApi {
     );
 
     @Operation(summary = "일반/AI 일정 수정", description = "일정의 세부 정보들을 수정합니다.")
-    @PatchMapping("/{planId}")
-    PlanDetailResponse updatePlan(
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            content = @Content(
+                    schema = @Schema(
+                            oneOf = { PlanUpdateRequest.class, AiPlanUpdateRequest.class },
+                            discriminatorProperty = "category"
+                    ),
+                    examples = {
+                            @ExampleObject(
+                                    name = "BASIC 요청 예시",
+                                    value = """
+                            {
+                              "category": "BASIC",
+                              "title": "일반 일정 제목 수정",
+                              "deadline": "2025-08-30T23:59:59",
+                              "priority": "HIGH",
+                              "scheduledStart" : "2025-08-30T23:59:59",
+                              "scheduledEnd" : "2025-08-30T23:59:59",
+                              "description" : "한줄설명",
+                              "delete" : false
+                            }
+                """
+                            ),
+                            @ExampleObject(
+                                    name = "AI 요청 예시(새로운 일정 id는 꼭 null로 입력)",
+                                    value = """
+                                            {
+                                              "category": "AI",
+                                              "title": "AI 상위 일정 제목 수정",
+                                              "deadline": "2025-08-30T23:59:59",
+                                              "priority": "MEDIUM",
+                                              "taskRange": "UNIT",
+                                              "plans": [
+                                                {
+                                                  "aiPlanId": 2, 
+                                                  "date": "2025-08-14",
+                                                  "description": "세부 작업 내용 수정",
+                                                  "expectedDuration": 120,
+                                                  "startTime": "13:00:00",
+                                                  "endTime": "14:30:00",
+                                                  "delete": false
+                                                },
+                                                {
+                                                  "aiPlanId": null, 
+                                                  "date": "2025-08-15",
+                                                  "description": "새로운 AI 일정",
+                                                  "expectedDuration": 90,
+                                                  "startTime": "15:00:00",
+                                                  "endTime": "16:30:00",
+                                                  "delete": false
+                                                }
+                                              ]
+                                            }
+                                            
+                """
+                            )
+                    }
+            )
+    )
+    UpdateResponse updatePlan(
             @PathVariable Long planId,
-            @RequestBody @Valid PlanUpdateRequest request,
+            @org.springframework.web.bind.annotation.RequestBody @Valid ScheduleUpdateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 

--- a/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
+++ b/src/main/java/dgu/umc_app/domain/plan/controller/PlanController.java
@@ -1,16 +1,12 @@
 package dgu.umc_app.domain.plan.controller;
 
-import dgu.umc_app.domain.plan.dto.request.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanDelayRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanUpdateRequest;
+import dgu.umc_app.domain.plan.dto.request.*;
 import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.domain.plan.entity.Category;
 import dgu.umc_app.domain.plan.repository.AiPlanRepository;
 import dgu.umc_app.domain.plan.repository.PlanRepository;
 import dgu.umc_app.domain.plan.service.PlanCommandService;
 import dgu.umc_app.domain.plan.service.PlanQueryService;
-import dgu.umc_app.domain.user.entity.User;
 import dgu.umc_app.global.authorize.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/schedule")
+@RequestMapping("/api/schedules")
 @RequiredArgsConstructor
 public class PlanController implements PlanApi{
 
@@ -40,7 +36,7 @@ public class PlanController implements PlanApi{
         return planCommandService.createPlan(request, userDetails.getUser());
     }
 
-    @GetMapping
+    @GetMapping("/monthly")
     public List<CalendarMonthResponse> getSchedulesByMonth(
             @RequestParam int year,
             @RequestParam int month,
@@ -50,13 +46,20 @@ public class PlanController implements PlanApi{
     }
 
     @GetMapping("/delayed")
-    public List<DelayedPlanResponse> getDelayedPlans(
+    public List<PausedPlanResponse> getDelayedPlans(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         return planQueryService.getDelayedPlans(userDetails.getUser());
     }
 
-    @GetMapping("/day")
+    @GetMapping("/unstarted")
+    public List<UnstartedPlanResponse> getUnstartedPlans(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return planQueryService.getUnstartedPlans(userDetails.getUser());
+    }
+
+    @GetMapping("/daily")
     public CalendarDayWrapperResponse getSchedulesByDay(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)LocalDate date,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -64,7 +67,7 @@ public class PlanController implements PlanApi{
         return planQueryService.getSchedulesByDate(date, userDetails.getUser());
     }
 
-    @PostMapping("/{planId}/split")
+    @PostMapping("/{planId}/aiplans")
     public List<PlanSplitResponse> splitPlan(
             @PathVariable Long planId,
             @RequestBody @Valid PlanSplitRequest request,
@@ -74,20 +77,13 @@ public class PlanController implements PlanApi{
         return planCommandService.splitPlan(planId, request, userDetails.getUser());
     }
 
-    @GetMapping("/unfinished")
-    public List<UnstartedPlanResponse> getUnfinishedPlans(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        return planQueryService.getUnstartedPlans(userDetails.getUser());
-    }
-
     @PatchMapping("/{planId}")
-    public PlanDetailResponse updatePlan(
+    public UpdateResponse updatePlan(
             @PathVariable Long planId,
-            @RequestBody @Valid PlanUpdateRequest request,
+            @RequestBody @Valid ScheduleUpdateRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return planCommandService.updatePlan(planId, request, userDetails.getUser());
+        return planCommandService.updateSchedule(planId, request, userDetails.getUser());
     }
 
     @GetMapping("/{planId}")
@@ -98,7 +94,7 @@ public class PlanController implements PlanApi{
         return planQueryService.getPlanDetail(planId, userDetails.getUser().getId());
     }
 
-    @PatchMapping("/{planId}/delay")
+    @PatchMapping("/{planId}/timeslot")
     public PlanDelayResponse delayPlan(
             @PathVariable Long planId,
             @RequestBody @Valid PlanDelayRequest request,

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/AiDetailUpdate.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/AiDetailUpdate.java
@@ -1,0 +1,34 @@
+package dgu.umc_app.domain.plan.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record AiDetailUpdate(
+        @Schema(description = "세부 일정 ID")
+        Long aiPlanId,
+
+        @Schema(description = "세부 일정 수행 날짜", example = "2025-08-22")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate date,
+
+        @Schema(description = "세부 일정 내용", example = "기획안 작성 4-5페이지까지")
+        String description,
+
+        @Schema(description = "예상 소요 시간", example = "120")
+        Long expectedDuration,
+
+        @Schema(description = "예상 시작 시간", example = "15:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime startTime,
+
+        @Schema(description = "예상 종료 시간", example = "16:30:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime endTime,
+
+        @Schema(description = "삭제 여부")
+        Boolean delete
+) {
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/AiPlanUpdateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/AiPlanUpdateRequest.java
@@ -1,0 +1,34 @@
+package dgu.umc_app.domain.plan.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import dgu.umc_app.domain.plan.entity.Category;
+import dgu.umc_app.domain.plan.entity.Priority;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public record AiPlanUpdateRequest(
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "AI")
+        @NotNull
+        Category category,
+
+        @Schema(description = "상위 일정 제목")
+        String title,
+
+        @Schema(description = "마감기한", example = "2025-08-30T23:59:59")
+        LocalDateTime deadline,
+
+        @Schema(description = "일정 범위")
+        String taskRange,
+
+        @Schema(description = "우선 순위")
+        Priority priority,
+
+        @Schema(description = "세부 일정 리스트")
+        List<AiDetailUpdate> plans
+) implements ScheduleUpdateRequest{ }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/BasicDetailUpdate.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/BasicDetailUpdate.java
@@ -2,34 +2,32 @@ package dgu.umc_app.domain.plan.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public record AiPlanUpdate(
+public record BasicDetailUpdate(
 
-        @Schema(description = "AI 세부 일정 ID (신규 생성 시 null)")
-        Long id,
+        @Schema(description = "일정 ID")
+        Long planId,
 
-        @Schema(description = "일정 수행 시작 날짜")
+        @Schema(description = "일정 수행 날짜")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate date,
 
-        @Schema(description = "할 일")
+        @Schema(description = "일반 세부 일정")
         String description,
-
-        @Schema(description = "예상 소요 시간")
-        Long expectedDuration,
 
         @Schema(description = "예상 시작 시간")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime scheduledStartTime,
+        LocalTime startTime,
 
         @Schema(description = "예상 종료 시간")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime scheduledEndTime,
+        LocalTime endTime,
 
-        @Schema(description = "삭제 여부", example = "false")
-        Boolean aiDelete
+        @Schema(description = "삭제 여부")
+        Boolean delete
 ) {
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanUpdateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/PlanUpdateRequest.java
@@ -6,6 +6,7 @@ import dgu.umc_app.domain.plan.exception.AiPlanErrorCode;
 import dgu.umc_app.domain.plan.exception.PlanErrorCode;
 import dgu.umc_app.global.exception.BaseException;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,131 +16,30 @@ import java.util.Map;
 
 public record PlanUpdateRequest(
 
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "BASIC")
+        @NotNull
+        Category category,
+
         @Schema(description = "일정 제목")
         String title,
 
-        @Schema(description = "마감기한")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-        LocalDate deadline,
-
-        @Schema(description = "일정 범위")
-        String taskRange,
+        @Schema(description = "마감기한", example = "2025-08-30T23:59:59")
+        LocalDateTime deadline,
 
         @Schema(description = "우선 순위")
         Priority priority,
 
-        @Schema(description = "일반 일정의 내용")
+        @Schema(description = "실행시작날짜")
+        LocalDateTime scheduledStart,
+
+        @Schema(description = "실행종료날짜")
+        LocalDateTime scheduledEnd,
+
+        @Schema(description = "일정 간단 설명")
         String description,
 
-        @Schema(description = "일정 수행 날짜")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-        LocalDate date,
-
-        @Schema(description = "예상 시작 시간")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime startTime,
-
-        @Schema(description = "예상 종료 시간")
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
-        LocalTime endTime,
-
-        @Schema(description = "상세 일정 리스트")
-        List<AiPlanUpdate> plans
-) {
-
-    public void applyToPlan(Plan plan) {
-        if (title != null) plan.updateTitle(title);
-        if(deadline != null) plan.updateDeadline(deadline.atTime(23, 59, 59));
-        if (priority != null) plan.updatePriority(priority);
-        if (description != null) plan.updateDescription(description);
-
-        if (date != null && startTime != null) {
-            plan.updateScheduledStart(LocalDateTime.of(date, startTime));
-        }
-        if (date != null && endTime != null) {
-            plan.updateScheduledEnd(LocalDateTime.of(date, endTime));
-        }
-
-        // 시간 검증
-        if (date != null && startTime != null && endTime != null) {
-            LocalDateTime start = LocalDateTime.of(date, startTime);
-            LocalDateTime end   = LocalDateTime.of(date, endTime);
-            if (end.isBefore(start)) {
-                throw new BaseException(PlanErrorCode.INVALID_DATE_RANGE);
-            }
-        }
-    }
-
-    private void assertWithinDeadline(Plan plan, LocalDateTime start, LocalDateTime end) {
-        if (end.isAfter(plan.getDeadline())) {
-            throw new BaseException(AiPlanErrorCode.AFTER_DEADLINE);
-        }
-    }
-
-    public void mergeIntoAiPlan(Plan plan, Map<Long, AiPlan> existing) {
-        if (plans == null || plans.isEmpty()) return;
-
-        final Priority propagatedPriority = (priority != null ? priority : plan.getPriority());
-
-        for (int i = 0; i < plans.size(); i++) {
-            var d = plans.get(i);
-
-            // 삭제: d.aiDelete() == true면 제거
-            if (d.aiDelete() != null && d.aiDelete()) {
-                if (d.id() != null && existing.containsKey(d.id())) {
-                    plan.removeAiPlan(existing.get(d.id()));
-                }
-                continue;
-            }
-
-            // 신규 생성
-            if (d.id() == null) {
-                LocalDateTime start = LocalDateTime.of(d.date(), d.scheduledStartTime());
-                LocalDateTime end   = LocalDateTime.of(d.date(), d.scheduledEndTime());
-                assertWithinDeadline(plan, start, end);
-
-                AiPlan.AiPlanBuilder b = AiPlan.builder()
-                        .plan(plan)
-                        .stepOrder((long) (i + 1))
-                        .priority(propagatedPriority)
-                        .taskRange(taskRange)
-                        .description(d.description())
-                        .expectedDuration(d.expectedDuration())
-                        .scheduledStart(start)
-                        .scheduledEnd(end)
-                        .status(Status.NOT_STARTED)
-                        .isDelayed(false)
-                        .planType(PlanType.IMMERSIVE);
-
-                plan.addAiPlan(b.build());
-                continue;
-            }
-
-            // 기존 항목 부분 수정 (planType은 유지)
-            AiPlan target = existing.get(d.id());
-            if (target == null) continue;
-
-            LocalDateTime newStart = target.getScheduledStart();
-            LocalDateTime newEnd   = target.getScheduledEnd();
-
-            if (d.date() != null && d.scheduledStartTime() != null)
-                target.updateScheduleStart(LocalDateTime.of(d.date(), d.scheduledStartTime()));
-            if (d.date() != null && d.scheduledEndTime() != null)
-                target.updateScheduleEnd(LocalDateTime.of(d.date(), d.scheduledEndTime()));
-
-            if (!newEnd.equals(target.getScheduledEnd())) {
-                assertWithinDeadline(plan, newStart, newEnd);
-            }
-
-            if (d.description() != null) target.updateDescription(d.description());
-            if (d.expectedDuration() != null) target.updateExpectedDuration(d.expectedDuration());
-            if (d.date() != null && d.scheduledStartTime() != null) target.updateScheduleStart(newStart);
-            if (d.date() != null && d.scheduledEndTime() != null)   target.updateScheduleEnd(newEnd);
-            if (priority != null) target.updatePriority(propagatedPriority);
-            if (taskRange != null) target.updateTaskRange(taskRange);
-        }
-    }
-}
-
+        @Schema(description = "삭제 여부")
+        Boolean delete
+) implements ScheduleUpdateRequest { }
 
 

--- a/src/main/java/dgu/umc_app/domain/plan/dto/request/ScheduleUpdateRequest.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/request/ScheduleUpdateRequest.java
@@ -1,0 +1,30 @@
+package dgu.umc_app.domain.plan.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import dgu.umc_app.domain.plan.entity.Category;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        description = "일정 수정 요청 (BASIC/AI)",
+        oneOf = { PlanUpdateRequest.class, AiPlanUpdateRequest.class },
+        discriminatorProperty = "category",
+        discriminatorMapping = {
+                @DiscriminatorMapping(value = "BASIC", schema = PlanUpdateRequest.class),
+                @DiscriminatorMapping(value = "AI", schema = AiPlanUpdateRequest.class)
+        }
+)
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "category",
+        visible = true
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = PlanUpdateRequest.class, name = "BASIC"),
+        @JsonSubTypes.Type(value = AiPlanUpdateRequest.class, name = "AI")
+})
+public interface ScheduleUpdateRequest {
+    Category category();
+}

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PausedPlanResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PausedPlanResponse.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-public record DelayedPlanResponse (
+public record PausedPlanResponse(
         Long id,
         String title,
         LocalDateTime scheduledStart,
@@ -15,8 +15,8 @@ public record DelayedPlanResponse (
         @Schema(description = "일정 유형(미루기 일정 판단)")
         Category category
 ){
-    public static DelayedPlanResponse from(Plan plan) {
-        return new DelayedPlanResponse(
+    public static PausedPlanResponse from(Plan plan) {
+        return new PausedPlanResponse(
                 plan.getId(),
                 plan.getTitle(),
                 plan.getScheduledStart(),
@@ -24,8 +24,8 @@ public record DelayedPlanResponse (
         );
     }
 
-    public static DelayedPlanResponse from(AiPlan aiPlan) {
-        return new DelayedPlanResponse(
+    public static PausedPlanResponse from(AiPlan aiPlan) {
+        return new PausedPlanResponse(
                 aiPlan.getId(),
                 aiPlan.getDescription(),
                 aiPlan.getScheduledStart(),

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanCreateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanCreateResponse.java
@@ -19,6 +19,9 @@ public record PlanCreateResponse(
         @Schema(description = "일정 수행 시작날짜")
         LocalDateTime scheduledStart,
 
+        @Schema(description = "일정 수행 종료날짜")
+        LocalDateTime scheduledEnd,
+
         @Schema(description = "일정 완료 여부")
         boolean isDone
 
@@ -29,6 +32,7 @@ public record PlanCreateResponse(
                 plan.getTitle(),
                 plan.getDeadline(),
                 plan.getScheduledStart(),
+                plan.getScheduledEnd(),
                 plan.isDone()
         );
     }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetail.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetail.java
@@ -1,5 +1,6 @@
 package dgu.umc_app.domain.plan.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDate;
@@ -10,19 +11,19 @@ public record PlanDetail(
         @Schema(description = "일정 ID")
         Long planId,
 
-        @Schema(description = "일정 수행 시작 날짜")
+        @Schema(description = "일정 수행 날짜")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
         LocalDate date,
 
-        @Schema(description = "할 일")
+        @Schema(description = "일반 세부 일정")
         String description,
 
-        @Schema(description = "예상 소요 시간")
-        Long expectedDuration,
-
         @Schema(description = "예상 시작 시간")
-        LocalTime scheduledStartTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime startTime,
 
         @Schema(description = "예상 종료 시간")
-        LocalTime scheduledEndTime
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime endTime
 ) {
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetailResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/PlanDetailResponse.java
@@ -1,8 +1,12 @@
 package dgu.umc_app.domain.plan.dto.response;
 
+import dgu.umc_app.domain.plan.dto.request.BasicDetailUpdate;
 import dgu.umc_app.domain.plan.entity.AiPlan;
+import dgu.umc_app.domain.plan.entity.Category;
 import dgu.umc_app.domain.plan.entity.Plan;
+import dgu.umc_app.domain.plan.entity.Priority;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -10,19 +14,20 @@ import java.util.List;
 
 public record PlanDetailResponse(
 
+        @Schema(example = "BASIC")
+        @NotNull
+        Category category,
+
         @Schema(description = "일정 제목")
         String title,
 
-        @Schema(description = "마감기한")
+        @Schema(description = "마감기한", example = "2025-08-30T23:59:59")
         LocalDateTime deadline,
 
-        @Schema(description = "일정 범위")
-        String taskRange,
-
         @Schema(description = "우선 순위")
-        String priority,
+        Priority priority,
 
-        @Schema(description = "상세 일정 리스트")
+        @Schema(description = "일반 세부일정 리스트")
         List<PlanDetail> plans
 ) {
     public static PlanDetailResponse fromPlan(Plan plan) {
@@ -32,39 +37,17 @@ public record PlanDetailResponse(
         ).toMinutes();
 
         return new PlanDetailResponse(
+                Category.BASIC,
                 plan.getTitle(),
                 plan.getDeadline(),
-                "", // 일반일정은 range 없음
-                plan.getPriority().name(),
+                plan.getPriority(),
                 List.of(new PlanDetail(
                         plan.getId(),
                         plan.getScheduledStart().toLocalDate(),
                         plan.getDescription(),
-                        expectedDuration,
                         plan.getScheduledStart().toLocalTime(),
                         plan.getScheduledEnd().toLocalTime()
                 ))
-        );
-    }
-
-    public static PlanDetailResponse fromAiPlan(Plan plan, List<AiPlan> aiPlans) {
-        List<PlanDetail> details = aiPlans.stream()
-                .map(ai -> new PlanDetail(
-                        ai.getId(),
-                        ai.getScheduledStart().toLocalDate(),
-                        ai.getDescription(),
-                        ai.getExpectedDuration(),
-                        ai.getScheduledStart().toLocalTime(),
-                        ai.getScheduledEnd().toLocalTime()
-                ))
-                .toList();
-
-        return new PlanDetailResponse(
-                plan.getTitle(),
-                plan.getDeadline(),
-                aiPlans.get(0).getTaskRange(),
-                plan.getPriority().name(),
-                details
         );
     }
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/UpdateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/UpdateResponse.java
@@ -9,17 +9,11 @@ public record UpdateResponse(
         @Schema(description = "상위 Plan ID", example = "12")
         Long planId,
 
-        @Schema(description = "AI 세부 일정 ID (BASIC이면 null)", example = "34")
-        Long aiPlanId,
-
         @Schema(description = "갱신 시각", example = "2025-08-14T06:22:10.123")
         LocalDateTime updatedAt
 ) {
     public static UpdateResponse fromPlan(Long planId, LocalDateTime updatedAt) {
-        return new UpdateResponse(planId, null, updatedAt);
+        return new UpdateResponse(planId, updatedAt);
     }
 
-    public static UpdateResponse fromAiPlan(Long planId, Long aiPlanId, LocalDateTime updatedAt) {
-        return new UpdateResponse(planId, aiPlanId, updatedAt);
-    }
 }

--- a/src/main/java/dgu/umc_app/domain/plan/dto/response/UpdateResponse.java
+++ b/src/main/java/dgu/umc_app/domain/plan/dto/response/UpdateResponse.java
@@ -1,0 +1,25 @@
+package dgu.umc_app.domain.plan.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "일정 수정 결과")
+public record UpdateResponse(
+        @Schema(description = "상위 Plan ID", example = "12")
+        Long planId,
+
+        @Schema(description = "AI 세부 일정 ID (BASIC이면 null)", example = "34")
+        Long aiPlanId,
+
+        @Schema(description = "갱신 시각", example = "2025-08-14T06:22:10.123")
+        LocalDateTime updatedAt
+) {
+    public static UpdateResponse fromPlan(Long planId, LocalDateTime updatedAt) {
+        return new UpdateResponse(planId, null, updatedAt);
+    }
+
+    public static UpdateResponse fromAiPlan(Long planId, Long aiPlanId, LocalDateTime updatedAt) {
+        return new UpdateResponse(planId, aiPlanId, updatedAt);
+    }
+}

--- a/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
+++ b/src/main/java/dgu/umc_app/domain/plan/entity/Plan.java
@@ -39,7 +39,7 @@ public class Plan extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime scheduledEnd; // 수행종료 예정 날짜&시간(ex: 2025-05-01T22:00:00)
 
-    @Column(nullable = false)
+    @Column
     private boolean isDone; // 완료 체크
 
     @Column
@@ -83,4 +83,5 @@ public class Plan extends BaseEntity {
     public void updateDescription(String description) {this.description = description;}
     public void updateScheduledStart(LocalDateTime scheduledStart) {this.scheduledStart = scheduledStart;}
     public void updateScheduledEnd(LocalDateTime scheduledEnd) {this.scheduledEnd = scheduledEnd;}
+    public void touch() {this.updatedAt = LocalDateTime.now();}
 }

--- a/src/main/java/dgu/umc_app/domain/plan/exception/PlanErrorCode.java
+++ b/src/main/java/dgu/umc_app/domain/plan/exception/PlanErrorCode.java
@@ -9,9 +9,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlanErrorCode implements ErrorCode {
 
-    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "PLAN400_1", "시작일은 종료일보다 이전이어야 합니다."),
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN404_1", "해당 일정이 존재하지 않습니다."),
-    INVALID_CATEGORY(HttpStatus.NOT_FOUND, "PLAN404_2", "해당 카테고리가 존재하지 않습니다.");
+    INVALID_CATEGORY(HttpStatus.NOT_FOUND, "PLAN404_2", "해당 카테고리가 존재하지 않습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "PLAN400_1", "시작일은 종료일보다 이전이어야 합니다."),
+    CANNOT_DELETE_BASE_PLAN(HttpStatus.BAD_REQUEST, "PLAN400_2", "기존 일정 삭제를 방지합니다."),
+    PAST_DEADLINE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "PLAN400_3", "마감 기한은 오늘 이전일 수 없습니다."),
+    PAST_START_NOT_ALLOWED   (HttpStatus.BAD_REQUEST, "PLAN400_4", "시작 시간은 오늘 이전일 수 없습니다."),
+    PAST_END_NOT_ALLOWED     (HttpStatus.BAD_REQUEST, "PLAN400_5", "종료 시간은 오늘 이전일 수 없습니다.");
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
@@ -14,7 +14,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
@@ -1,13 +1,7 @@
 package dgu.umc_app.domain.plan.service;
 
-import dgu.umc_app.domain.plan.dto.request.PlanCreateRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanDelayRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanSplitRequest;
-import dgu.umc_app.domain.plan.dto.request.PlanUpdateRequest;
-import dgu.umc_app.domain.plan.dto.response.PlanCreateResponse;
-import dgu.umc_app.domain.plan.dto.response.PlanDelayResponse;
-import dgu.umc_app.domain.plan.dto.response.PlanDetailResponse;
-import dgu.umc_app.domain.plan.dto.response.PlanSplitResponse;
+import dgu.umc_app.domain.plan.dto.request.*;
+import dgu.umc_app.domain.plan.dto.response.*;
 import dgu.umc_app.domain.plan.entity.*;
 import dgu.umc_app.domain.plan.exception.AiPlanErrorCode;
 import dgu.umc_app.domain.plan.exception.PlanErrorCode;
@@ -20,6 +14,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -27,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -162,66 +156,164 @@ public class PlanCommandService {
         return splitResponses;
     }
 
-    @Transactional
-    public PlanDetailResponse updatePlan(Long planId, PlanUpdateRequest request, User user) {
-
-        // 1) 소유자 검증 + 로드
-        Plan plan = planRepository.findByIdWithUserId(planId, user.getId())
-                .orElseThrow(() -> new BaseException(PlanErrorCode.PLAN_NOT_FOUND));
-
-        // 2) 상위 Plan 부분 수정
-        request.applyToPlan(plan);
-
-        // 3) 신규/부분수정 검증 (신규 AiPlan not-null, 시간 범위 등)
-        validateForMerge(request);
-
-        // 4) 기존 AiPlan 맵(id -> entity)
-        Map<Long, AiPlan> existing = plan.getAiPlans().stream()
-                .collect(Collectors.toMap(AiPlan::getId, a -> a));
-
-        // 5) AiPlan 컬렉션 부분 수정/추가/삭제 (planType 보존, 신규만 기본값)
-        request.mergeIntoAiPlan(plan, existing);
-
-        // 6) stepOrder normalize (1..N)
-        long order = 1L;
-        for (AiPlan ap : plan.getAiPlans()) {
-            ap.updateStepOrder(order++);
-        }
-
-        // 7) 저장 및 응답 (일반 일정/AI 일정에 따라 분기)
-        if (plan.getAiPlans() == null || plan.getAiPlans().isEmpty()) {
-            return PlanDetailResponse.fromPlan(plan);
-        } else {
-            return PlanDetailResponse.fromAiPlan(plan, plan.getAiPlans());
+    private void assertTimeOrder(LocalDateTime start, LocalDateTime end) {
+        if (start != null && end != null && end.isBefore(start)) {
+            throw BaseException.type(PlanErrorCode.INVALID_DATE_RANGE);
         }
     }
-    private void validateForMerge(PlanUpdateRequest req) {
-        if (req.plans() == null) return;
 
-        for (var d : req.plans()) {
-            // 신규 + 삭제 조합 방지
-            if (d.id() == null && Boolean.TRUE.equals(d.aiDelete())) {
-                throw new BaseException(AiPlanErrorCode.INVALID_REQUEST_STATE);
+    @Transactional
+    public UpdateResponse updateSchedule(Long planId, ScheduleUpdateRequest req, User user) {
+        if (req instanceof PlanUpdateRequest r) {
+            return updateBasicPlan(planId, r, user);
+        } else if (req instanceof AiPlanUpdateRequest r) {
+            return updateAiPlan(planId, r, user);
+        } else {
+            throw new IllegalArgumentException("Unknown request type: " + req.getClass());
+        }
+    }
+    private static <T> T nvl(T v, T fallback) { return v != null ? v : fallback; }
+
+    private static void assertWithinDeadline(LocalDateTime deadline, LocalDateTime end) {
+        if (deadline != null && end != null && end.isAfter(deadline)) {
+            throw BaseException.type(AiPlanErrorCode.AFTER_DEADLINE);
+        }
+    }
+    private void assertStartEndRequired(LocalDateTime start, LocalDateTime end) {
+        if (start == null || end == null) {
+            throw BaseException.type(PlanErrorCode.INVALID_DATE_RANGE); // "시작/종료 시간은 필수" 등 전용 코드 권장
+        }
+    }
+
+    private void assertNotBeforeToday(LocalDateTime dt, PlanErrorCode code) {
+        if (dt != null && dt.isBefore(LocalDateTime.now())) {
+            throw BaseException.type(code);
+        }
+    }
+
+    @Transactional
+    public UpdateResponse updateBasicPlan(Long planId, PlanUpdateRequest req, User user) {
+
+        Plan base = planRepository.findByIdWithUserId(planId, user.getId())
+                .orElseThrow(() -> BaseException.type(PlanErrorCode.PLAN_NOT_FOUND));
+
+        if (req.title() != null)    base.updateTitle(req.title());
+        if (req.priority() != null) base.updatePriority(req.priority());
+        if (req.deadline() != null){
+            assertNotBeforeToday(req.deadline(), PlanErrorCode.PAST_DEADLINE_NOT_ALLOWED);
+            base.updateDeadline(req.deadline());
+        }
+        if (req.description() != null) base.updateDescription(req.description());
+
+        LocalDateTime newStart = base.getScheduledStart();
+        LocalDateTime newEnd   = base.getScheduledEnd();
+
+        assertTimeOrder(newStart, newEnd);
+        assertWithinDeadline(nvl(req.deadline(), base.getDeadline()), newEnd);
+        assertNotBeforeToday(newStart, PlanErrorCode.PAST_START_NOT_ALLOWED);
+        assertNotBeforeToday(newEnd,   PlanErrorCode.PAST_END_NOT_ALLOWED);
+
+        base.updateScheduledStart(newStart);
+        base.updateScheduledEnd(newEnd);
+
+        base.touch();
+        return UpdateResponse.fromPlan(planId, base.getUpdatedAt());
+    }
+
+    @Transactional
+    public UpdateResponse updateAiPlan(Long planId, AiPlanUpdateRequest req, User user) {
+
+        // 상위 일정 조회 먼저
+        Plan plan = planRepository.findByIdWithUserId(planId, user.getId())
+                .orElseThrow(() -> BaseException.type(PlanErrorCode.PLAN_NOT_FOUND));
+
+        if (req.title() != null)     plan.updateTitle(req.title());
+        if (req.priority() != null)  plan.updatePriority(req.priority());
+        if (req.deadline() != null){
+            assertNotBeforeToday(req.deadline(), PlanErrorCode.PAST_DEADLINE_NOT_ALLOWED);
+            plan.updateDeadline(req.deadline());
+        }
+
+        Map<Long, AiPlan> existing = plan.getAiPlans().stream()
+                .collect(java.util.stream.Collectors.toMap(AiPlan::getId, java.util.function.Function.identity()));
+
+
+        PlanType basePlanType = plan.getAiPlans().stream()
+                .map(AiPlan::getPlanType)
+                .filter(java.util.Objects::nonNull)
+                .findFirst()
+                .orElse(PlanType.IMMERSIVE);
+
+        int order = 1;
+        if (req.plans() != null) {
+            for (AiDetailUpdate d : req.plans()) {
+                // 삭제
+                if (Boolean.TRUE.equals(d.delete())) {
+                    if (d.aiPlanId() != null && existing.containsKey(d.aiPlanId())) {
+                        plan.removeAiPlan(existing.get(d.aiPlanId()));
+                    }
+                    continue;
+                }
+
+                // 시간 계산
+                LocalDateTime start = (d.date() != null && d.startTime() != null)
+                        ? LocalDateTime.of(d.date(), d.startTime())
+                        : null;
+                LocalDateTime end = (d.date() != null && d.endTime() != null)
+                        ? LocalDateTime.of(d.date(), d.endTime())
+                        : null;
+
+                // 신규 생성
+                if (d.aiPlanId() == null) {
+                    assertNotBeforeToday(start, PlanErrorCode.PAST_START_NOT_ALLOWED);
+                    assertNotBeforeToday(end,   PlanErrorCode.PAST_END_NOT_ALLOWED);
+                    assertStartEndRequired(start, end);
+                    assertTimeOrder(start, end);
+                    assertWithinDeadline(plan.getDeadline(), end);
+
+                    AiPlan ai = AiPlan.builder()
+                            .plan(plan)
+                            .stepOrder((long) order++)
+                            .priority(req.priority() != null ? req.priority() : plan.getPriority())
+                            .planType(basePlanType)
+                            .taskRange(req.taskRange())
+                            .description(d.description())
+                            .expectedDuration(d.expectedDuration())
+                            .scheduledStart(start)
+                            .scheduledEnd(end)
+                            .status(Status.NOT_STARTED)
+                            .isDelayed(false)
+                            .build();
+
+                    plan.addAiPlan(ai);
+                    continue;
+                }
+                // 수정
+                AiPlan target = existing.get(d.aiPlanId());
+                if (target == null) continue;
+
+                // 부분 수정 허용(널은 유지)
+                if (d.description() != null) target.updateDescription(d.description());
+                if (d.expectedDuration() != null) target.updateExpectedDuration(d.expectedDuration());
+                if (start != null) target.updateScheduleStart(start);
+                if (end != null) target.updateScheduleEnd(end);
+                if (req.priority() != null) target.updatePriority(req.priority());
+                if (req.taskRange() != null) target.updateTaskRange(req.taskRange());
+                // planType은 유지
+
+                assertNotBeforeToday(target.getScheduledStart(), PlanErrorCode.PAST_START_NOT_ALLOWED);
+                assertNotBeforeToday(target.getScheduledEnd(),   PlanErrorCode.PAST_END_NOT_ALLOWED);
+                assertTimeOrder(target.getScheduledStart(), target.getScheduledEnd());
+                assertWithinDeadline(plan.getDeadline(), target.getScheduledEnd());
             }
 
-            // 신규 생성 필수값 (AiPlan: description, expectedDuration, scheduledStart, scheduledEnd, planType(신규시 기본값으로 세팅), taskRange)
-            if (d.id() == null) {
-                boolean missing = d.description() == null
-                        || d.expectedDuration() == null
-                        || d.date() == null
-                        || d.scheduledStartTime() == null
-                        || d.scheduledEndTime() == null
-                        || req.taskRange() == null;
-                if (missing) throw new BaseException(AiPlanErrorCode.INVALID_AIPLAN_FIELDS);
-            }
-
-            // 시간 유효성
-            if (d.date() != null && d.scheduledStartTime() != null && d.scheduledEndTime() != null) {
-                var start = LocalDateTime.of(d.date(), d.scheduledStartTime());
-                var end   = LocalDateTime.of(d.date(), d.scheduledEndTime());
-                if (end.isBefore(start)) throw new BaseException(AiPlanErrorCode.INVALID_TIME_RANGE);
+            plan.getAiPlans().sort(java.util.Comparator.comparing(AiPlan::getScheduledStart));
+            for (int i = 0; i < plan.getAiPlans().size(); i++) {
+                plan.getAiPlans().get(i).updateStepOrder((long) (i + 1));
             }
         }
+            plan.touch();
+            return UpdateResponse.fromPlan(plan.getId(), plan.getUpdatedAt());
     }
 
     @Transactional

--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanQueryService.java
@@ -19,7 +19,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -104,15 +103,15 @@ public class PlanQueryService{
         return new CalendarDayWrapperResponse(result.size(), result);
     }
 
-    public List<DelayedPlanResponse> getDelayedPlans(User user) {
+    public List<PausedPlanResponse> getDelayedPlans(User user) {
         Long userId = user.getId();
 
         List<Plan> delayedPlans = planRepository.findByUserIdAndStatus(userId, Status.PAUSED);
         List<AiPlan> delayedAiPlans = aiPlanRepository.findByPlan_UserIdAndStatus(userId, Status.PAUSED);
 
-        List<DelayedPlanResponse> result = new ArrayList<>();
-        delayedPlans.forEach(plan -> result.add(DelayedPlanResponse.from(plan)));
-        delayedAiPlans.forEach(aiPlan -> result.add(DelayedPlanResponse.from(aiPlan)));
+        List<PausedPlanResponse> result = new ArrayList<>();
+        delayedPlans.forEach(plan -> result.add(PausedPlanResponse.from(plan)));
+        delayedAiPlans.forEach(aiPlan -> result.add(PausedPlanResponse.from(aiPlan)));
 
         return result;
     }
@@ -178,10 +177,10 @@ public class PlanQueryService{
         // 2. 해당 Plan이 AI 일정인지 확인
         List<AiPlan> aiPlans = aiPlanRepository.findByPlanId(planId);
 
-        if (!aiPlans.isEmpty()) {
-            // AI 일정이면
-            return PlanDetailResponse.fromAiPlan(plan, aiPlans);
-        }
+//        if (!aiPlans.isEmpty()) {
+//            // AI 일정이면
+//            return PlanDetailResponse.fromAiPlan(plan, aiPlans);
+//        }
 
         // 일반 일정이면
         return PlanDetailResponse.fromPlan(plan);


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #133 


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요 -->
- 일정 수정 dto 분리
- 일정 조회 dto 분리
- ScheduleUpdateRequest에서 category 기준으로 dto 구분

## 📸 스크린샷 (선택)
<!-- 실행 결과를 첨부해 주세요 -->

## 📢 참고 사항
<!-- 특별히 봐주었으면 하는 부분과 참고해야 할 사항이 있다면 작성해 주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<!-- ex) yml 변경했습니다 -->
