### PR TITLE
[ feat ] 배너/팝업 알람 호출 

### DIFF
--- a/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
+++ b/src/main/java/dgu/umc_app/domain/plan/service/PlanCommandService.java
@@ -195,6 +195,8 @@ public class PlanCommandService {
 
         planRepository.save(plan);
 
+        notificationScheduleService.cancelNotification(plan);
+
         return splitResponses;
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,4 +22,3 @@ spring:
         max-active: 10
         max-idle: 10
         min-idle: 2
-


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- close : #151 

## 📝 작업 내용
- update, delay, create에 alarm 추가하고 삭제하는 로직 넣어놨습니다

## 📸 스크린샷 (선택)

## 📢 참고 사항
알람은 현재 plan 과 AiPlan의 starttime과 endtime을 기준으로 작동하고 있는데
`updateBasicPlan` 에서는 Plan의 starttime과 endtime이 업데이트 되기 때문에 알람을 지우고 추가하는데 문제가 없었으나
`updateAiPlan`에서는 Plan의 deadline은 업데이트 되지만 starttime과 endtime은 업데이트 되지 않아 알람을 지우고 추가하지 않도록 현재 구현해 놓은 상태입니다 deadline은 갱신이 되지만 startTime과 endTime이 갱신이 되지 않는다면 알람이 업데이트 되지 않아 이상한 시간에 보내질 것 같은데 제가 이해한게 맞는지 여쭈어봅니다